### PR TITLE
✨ Spanner database processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Features:
 
 - Define Cloud Run-related configuration used by the [`causa-io/service-container-cloud-run/google`](https://github.com/causa-io/terraform-google-service-container-cloud-run) Terraform module.
+- Implement the `GoogleSpannerWriteDatabases` function and infrastructure processor.
 
 ## v0.3.1 (2023-06-09)
 

--- a/src/configurations/google.ts
+++ b/src/configurations/google.ts
@@ -215,6 +215,12 @@ export type GoogleConfiguration = {
          */
         readonly regularExpression?: string;
       };
+
+      /**
+       * The directory where the database configuration files are written by the `GoogleSpannerWriteDatabases`
+       * processor.
+       */
+      readonly databaseConfigurationsDirectory?: string;
     };
 
     /**

--- a/src/functions/google-spanner-write-databases.spec.ts
+++ b/src/functions/google-spanner-write-databases.spec.ts
@@ -1,0 +1,164 @@
+import { WorkspaceContext } from '@causa/workspace';
+import { createContext } from '@causa/workspace/testing';
+import { existsSync } from 'fs';
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'fs/promises';
+import 'jest-extended';
+import { join, resolve } from 'path';
+import { GoogleSpannerListDatabases } from './google-spanner-list-databases.js';
+import { GoogleSpannerWriteDatabases } from './google-spanner-write-databases.js';
+
+describe('GoogleSpannerWriteDatabases', () => {
+  const expectedDirectory = join('.causa', 'spanner-databases');
+  let context: WorkspaceContext;
+
+  beforeEach(async () => {
+    const rootPath = resolve(await mkdtemp('causa-test-'));
+    ({ context } = createContext({
+      rootPath,
+      configuration: {
+        workspace: { name: '🏷️' },
+        google: {
+          spanner: {
+            ddls: {
+              globs: ['*.sql'],
+              format: '${ database }',
+              regularExpression: '(?<database>[\\w-]+)-.+\\.sql',
+            },
+          },
+        },
+      },
+      functions: [GoogleSpannerWriteDatabases, GoogleSpannerListDatabases],
+    }));
+  });
+
+  afterEach(async () => {
+    await rm(context.rootPath, { recursive: true, force: true });
+  });
+
+  it('should not write any database file', async () => {
+    const actualResult = await context.call(GoogleSpannerWriteDatabases, {});
+
+    expect(actualResult).toEqual({
+      configuration: {
+        google: {
+          spanner: { databaseConfigurationsDirectory: expectedDirectory },
+        },
+      },
+    });
+    const actualFiles = await readdir(
+      join(context.rootPath, expectedDirectory),
+    );
+    expect(actualFiles).toBeEmpty();
+  });
+
+  it('should write database files to the default directory', async () => {
+    const db1File1 = join(context.rootPath, 'db1-1.sql');
+    const db1File2 = join(context.rootPath, 'db1-2.sql');
+    const db2File1 = join(context.rootPath, 'db2-1.sql');
+    await writeFile(
+      db1File1,
+      'CREATE TABLE a; -- comment to discard\nALTER TABLE a1',
+    );
+    await writeFile(db1File2, 'ALTER TABLE a2');
+    await writeFile(
+      db2File1,
+      'CREATE TABLE b(\nx,\ny,\nz,\n);\nALTER TABLE\nb1',
+    );
+
+    const actualResult = await context.call(GoogleSpannerWriteDatabases, {});
+
+    expect(actualResult).toEqual({
+      configuration: {
+        google: {
+          spanner: { databaseConfigurationsDirectory: expectedDirectory },
+        },
+      },
+    });
+    const actualDb1ConfigurationStr = await readFile(
+      join(context.rootPath, expectedDirectory, 'db1.json'),
+    );
+    const actualDb1Configuration = JSON.parse(
+      actualDb1ConfigurationStr.toString(),
+    );
+    expect(actualDb1Configuration).toEqual({
+      id: 'db1',
+      ddls: ['CREATE TABLE a', 'ALTER TABLE a1', 'ALTER TABLE a2'],
+      ddlFiles: [db1File1, db1File2],
+    });
+    const actualDb2ConfigurationStr = await readFile(
+      join(context.rootPath, expectedDirectory, 'db2.json'),
+    );
+    const actualDb2Configuration = JSON.parse(
+      actualDb2ConfigurationStr.toString(),
+    );
+    expect(actualDb2Configuration).toEqual({
+      id: 'db2',
+      ddls: ['CREATE TABLE b( x, y, z, )', 'ALTER TABLE b1'],
+      ddlFiles: [db2File1],
+    });
+  });
+
+  it('should write database files to the configured directory', async () => {
+    const db1File1 = join(context.rootPath, 'db1-1.sql');
+    await writeFile(
+      db1File1,
+      'CREATE TABLE a; -- comment to discard\nALTER TABLE a1',
+    );
+    const expectedDirectory = 'somewhere-else';
+    ({ context } = createContext({
+      rootPath: context.rootPath,
+      configuration: {
+        workspace: { name: '🏷️' },
+        google: {
+          spanner: {
+            ddls: {
+              globs: ['*.sql'],
+              format: '${ database }',
+              regularExpression: '(?<database>[\\w-]+)-.+\\.sql',
+            },
+            databaseConfigurationsDirectory: expectedDirectory,
+          },
+        },
+      },
+      functions: [GoogleSpannerWriteDatabases, GoogleSpannerListDatabases],
+    }));
+
+    const actualResult = await context.call(GoogleSpannerWriteDatabases, {});
+
+    expect(actualResult).toEqual({
+      configuration: {
+        google: {
+          spanner: { databaseConfigurationsDirectory: expectedDirectory },
+        },
+      },
+    });
+    const actualDb1ConfigurationStr = await readFile(
+      join(context.rootPath, expectedDirectory, 'db1.json'),
+    );
+    const actualDb1Configuration = JSON.parse(
+      actualDb1ConfigurationStr.toString(),
+    );
+    expect(actualDb1Configuration).toEqual({
+      id: 'db1',
+      ddls: ['CREATE TABLE a', 'ALTER TABLE a1'],
+      ddlFiles: [db1File1],
+    });
+  });
+
+  it('should clean the directory during tear down', async () => {
+    const db1File1 = join(context.rootPath, 'db1-1.sql');
+    await writeFile(
+      db1File1,
+      'CREATE TABLE a; -- comment to discard\nALTER TABLE a1',
+    );
+    await context.call(GoogleSpannerWriteDatabases, {});
+    const expectedAbsoluteDirectory = join(context.rootPath, expectedDirectory);
+    const existsAfterWrite = existsSync(expectedAbsoluteDirectory);
+
+    await context.call(GoogleSpannerWriteDatabases, { tearDown: true });
+    const existsAfterTearDown = existsSync(expectedAbsoluteDirectory);
+
+    expect(existsAfterWrite).toBeTrue();
+    expect(existsAfterTearDown).toBeFalse();
+  });
+});

--- a/src/functions/google-spanner-write-databases.ts
+++ b/src/functions/google-spanner-write-databases.ts
@@ -1,0 +1,125 @@
+import {
+  ProcessorResult,
+  WorkspaceContext,
+  WorkspaceFunction,
+} from '@causa/workspace';
+import { InfrastructureProcessor } from '@causa/workspace-core';
+import { CAUSA_FOLDER } from '@causa/workspace/initialization';
+import { AllowMissing } from '@causa/workspace/validation';
+import { IsBoolean } from 'class-validator';
+import { mkdir, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { GoogleConfiguration } from '../index.js';
+import { GoogleSpannerListDatabases } from './google-spanner-list-databases.js';
+
+/**
+ * The default directory where project configurations are written, relative to the workspace root.
+ */
+const DEFAULT_DATABASE_CONFIGURATIONS_DIRECTORY = join(
+  CAUSA_FOLDER,
+  'spanner-databases',
+);
+
+/**
+ * A function that uses {@link GoogleSpannerListDatabases} to find all the Spanner databases in the workspace, and
+ * writes their configurations to a directory.
+ * The `google.spanner.databaseConfigurationsDirectory` configuration can be used to specify the output location of the
+ * database configurations.
+ * This function returns a partial configuration, such that it can be used as a processor.
+ */
+export class GoogleSpannerWriteDatabases
+  extends WorkspaceFunction<Promise<ProcessorResult>>
+  implements InfrastructureProcessor
+{
+  @IsBoolean()
+  @AllowMissing()
+  readonly tearDown?: boolean;
+
+  /**
+   * Returns the path to the directory where Spanner databases configurations should be written.
+   * It is either fetched from the workspace configuration, or the default value is used.
+   *
+   * @param context The {@link WorkspaceContext}.
+   * @returns The path to the directory where database configurations should be written.
+   */
+  private getConfigurationsDirectory(context: WorkspaceContext): string {
+    return (
+      context
+        .asConfiguration<GoogleConfiguration>()
+        .get('google.spanner.databaseConfigurationsDirectory') ??
+      DEFAULT_DATABASE_CONFIGURATIONS_DIRECTORY
+    );
+  }
+
+  /**
+   * Removes the directory where database configurations are written.
+   * This is run when the `tearDown` option is set to `true`.
+   *
+   * @param context The {@link WorkspaceContext}.
+   * @returns An empty {@link ProcessorResult}.
+   */
+  private async tearDownConfigurationsDirectory(
+    context: WorkspaceContext,
+  ): Promise<ProcessorResult> {
+    const databaseConfigurationsDirectory =
+      this.getConfigurationsDirectory(context);
+
+    const absoluteDirectory = join(
+      context.rootPath,
+      databaseConfigurationsDirectory,
+    );
+
+    context.logger.debug(
+      `🔧 Tearing down Spanner database configurations directory '${absoluteDirectory}'.`,
+    );
+    await rm(absoluteDirectory, { recursive: true, force: true });
+
+    return { configuration: {} };
+  }
+
+  async _call(context: WorkspaceContext): Promise<ProcessorResult> {
+    if (this.tearDown) {
+      return await this.tearDownConfigurationsDirectory(context);
+    }
+
+    context.logger.info(
+      '🗃️ Listing and writing Spanner database configurations.',
+    );
+
+    const databases = await context.call(GoogleSpannerListDatabases, {});
+
+    const databaseConfigurationsDirectory =
+      this.getConfigurationsDirectory(context);
+    const absoluteDir = join(context.rootPath, databaseConfigurationsDirectory);
+
+    await mkdir(absoluteDir, { recursive: true });
+
+    context.logger.debug(
+      `🗃️ Writing configurations for Spanner databases: ${databases
+        .map((d) => `'${d.id}'`)
+        .join(', ')}.`,
+    );
+    await Promise.all(
+      databases.map((database) =>
+        writeFile(
+          join(absoluteDir, `${database.id}.json`),
+          JSON.stringify(database),
+        ),
+      ),
+    );
+
+    context.logger.debug(
+      `🗃️ Wrote Spanner database configurations in '${absoluteDir}'.`,
+    );
+
+    return {
+      configuration: {
+        google: { spanner: { databaseConfigurationsDirectory } },
+      },
+    };
+  }
+
+  _supports(): boolean {
+    return true;
+  }
+}

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -16,6 +16,7 @@ import { GoogleIdentityPlatformGenerateCustomToken } from './google-identity-pla
 import { GoogleIdentityPlatformGenerateToken } from './google-identity-platform-generate-token.js';
 import { GoogleServicesEnable } from './google-services-enable.js';
 import { GoogleSpannerListDatabases } from './google-spanner-list-databases.js';
+import { GoogleSpannerWriteDatabases } from './google-spanner-write-databases.js';
 import { ProjectGetArtefactDestinationForCloudFunctions } from './project-get-artefact-destination-cloud-functions.js';
 import { ProjectGetArtefactDestinationForCloudRun } from './project-get-artefact-destination-cloud-run.js';
 import { ProjectPushArtefactForCloudFunctions } from './project-push-artefact-cloud-functions.js';
@@ -40,6 +41,7 @@ export function registerFunctions(context: ModuleRegistrationContext) {
     GoogleIdentityPlatformGenerateToken,
     GoogleServicesEnable,
     GoogleSpannerListDatabases,
+    GoogleSpannerWriteDatabases,
     ProjectGetArtefactDestinationForCloudFunctions,
     ProjectGetArtefactDestinationForCloudRun,
     ProjectPushArtefactForCloudFunctions,


### PR DESCRIPTION
This PR implement the `GoogleSpannerWriteDatabases` infrastructure processor, which writes database definitions to a temporary folder.
It is meant to be used by a future Terraform module which will manage Spanner databases.

### Commits

- ✨ Implement the GoogleSpannerWriteDatabases function and processor
- 📝 Update changelog