### PR TITLE
✨ `GooglePubSubWriteTopics` function and processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Features:
 
 - Define Cloud Run-related configuration used by the [`causa-io/service-container-cloud-run/google`](https://github.com/causa-io/terraform-google-service-container-cloud-run) Terraform module.
 - Implement the `GoogleSpannerWriteDatabases` function and infrastructure processor.
+- Implement the `GooglePubSubWriteTopics` function and infrastructure processor.
 
 ## v0.3.1 (2023-06-09)
 

--- a/README.md
+++ b/README.md
@@ -114,3 +114,7 @@ The Google module provides several infrastructure processors, which can be used 
 [GoogleServicesEnable](./src/functions/google-services-enable.ts) is the same underlying function as the `cs google enableServices` command. It enables GCP services before preparing or deploying the infrastructure.
 
 Although infrastructure as code tools usually expose this feature as well (e.g. the [`google_project_service`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_service) Terraform resource), it might be more convenient to enable all the required services before running those tools. It avoids having to define dependencies between the services and all the actual resources being deployed.
+
+### `GooglePubSubWriteTopics`
+
+[GooglePubSubWriteTopics](./src/functions/google-pubsub-write-topics.ts) writes a configuration file for each event topic, such that it can be picked up by the Causa Pub/Sub Terraform module. This allows automatic setup of Pub/Sub topics, and optionally of the corresponding BigQuery tables.

--- a/src/configurations/google.ts
+++ b/src/configurations/google.ts
@@ -170,6 +170,21 @@ export type GoogleConfiguration = {
          */
         readonly containerName?: string;
       };
+
+      /**
+       * The directory where the topic configuration files are written by the `GooglePubSubWriteTopics` processor.
+       */
+      readonly topicConfigurationsDirectory?: string;
+
+      /**
+       * Configuration for the storage of Pub/Sub events in BigQuery.
+       */
+      readonly bigQueryStorage?: {
+        /**
+         * The ID of the BigQuery dataset where raw Pub/Sub events should be stored.
+         */
+        readonly rawEventsDatasetId?: string;
+      };
     };
 
     /**

--- a/src/functions/google-pubsub-write-topics.spec.ts
+++ b/src/functions/google-pubsub-write-topics.spec.ts
@@ -1,0 +1,140 @@
+import { WorkspaceContext } from '@causa/workspace';
+import coreModule from '@causa/workspace-core';
+import { FunctionRegistry } from '@causa/workspace/function-registry';
+import { createContext } from '@causa/workspace/testing';
+import { existsSync } from 'fs';
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'fs/promises';
+import 'jest-extended';
+import { join, resolve } from 'path';
+import { GooglePubSubWriteTopics } from './google-pubsub-write-topics.js';
+
+describe('GooglePubSubWriteTopics', () => {
+  const expectedDirectory = join('.causa', 'pubsub-topics');
+  let context: WorkspaceContext;
+  let functionRegistry: FunctionRegistry<WorkspaceContext>;
+
+  function createTestContext(
+    rootPath: string,
+    topicConfigurationsDirectory?: string,
+  ) {
+    ({ context, functionRegistry } = createContext({
+      rootPath,
+      configuration: {
+        events: {
+          topics: {
+            globs: ['**.yaml'],
+            format: '${ topic }',
+            regularExpression: '(?<topic>.+)\\.yaml',
+          },
+        },
+        google: { pubSub: { topicConfigurationsDirectory } },
+      },
+      functions: [GooglePubSubWriteTopics],
+    }));
+    coreModule({
+      registerFunctionImplementations: (...implementations) =>
+        functionRegistry.registerImplementations(...implementations),
+    });
+  }
+
+  beforeEach(async () => {
+    const rootPath = resolve(await mkdtemp('causa-test-'));
+    createTestContext(rootPath);
+  });
+
+  afterEach(async () => {
+    await rm(context.rootPath, { recursive: true, force: true });
+  });
+
+  it('should not write any topic file', async () => {
+    const actualResult = await context.call(GooglePubSubWriteTopics, {});
+
+    expect(actualResult).toEqual({
+      configuration: {
+        google: {
+          pubSub: { topicConfigurationsDirectory: expectedDirectory },
+        },
+      },
+    });
+    const actualFiles = await readdir(
+      join(context.rootPath, expectedDirectory),
+    );
+    expect(actualFiles).toBeEmpty();
+  });
+
+  it('should write topic files to the default directory', async () => {
+    const topicFile1 = join(context.rootPath, 'topic1.yaml');
+    const topicFile2 = join(context.rootPath, 'topic.with-punctuation.2.yaml');
+    await writeFile(topicFile1, 'name: topic1');
+    await writeFile(topicFile2, 'name: topic2');
+
+    const actualResult = await context.call(GooglePubSubWriteTopics, {});
+
+    expect(actualResult).toEqual({
+      configuration: {
+        google: {
+          pubSub: { topicConfigurationsDirectory: expectedDirectory },
+        },
+      },
+    });
+    const actualTopic1ConfigurationBuffer = await readFile(
+      join(context.rootPath, expectedDirectory, 'topic1.json'),
+    );
+    expect(JSON.parse(actualTopic1ConfigurationBuffer.toString())).toEqual({
+      id: 'topic1',
+      schemaFilePath: topicFile1,
+      formatParts: { topic: 'topic1' },
+      bigQueryTableName: 'topic1',
+    });
+    const actualTopic2ConfigurationBuffer = await readFile(
+      join(
+        context.rootPath,
+        expectedDirectory,
+        'topic.with-punctuation.2.json',
+      ),
+    );
+    expect(JSON.parse(actualTopic2ConfigurationBuffer.toString())).toEqual({
+      id: 'topic.with-punctuation.2',
+      schemaFilePath: topicFile2,
+      formatParts: { topic: 'topic.with-punctuation.2' },
+      bigQueryTableName: 'topic_with_punctuation_2',
+    });
+  });
+
+  it('should write topic files to the specified directory', async () => {
+    createTestContext(context.rootPath, 'somewhere-else');
+    const topicFile1 = join(context.rootPath, 'topic1.yaml');
+    await writeFile(topicFile1, 'name: topic1');
+
+    const actualResult = await context.call(GooglePubSubWriteTopics, {});
+
+    expect(actualResult).toEqual({
+      configuration: {
+        google: {
+          pubSub: { topicConfigurationsDirectory: 'somewhere-else' },
+        },
+      },
+    });
+    const actualTopic1ConfigurationBuffer = await readFile(
+      join(context.rootPath, 'somewhere-else', 'topic1.json'),
+    );
+    expect(JSON.parse(actualTopic1ConfigurationBuffer.toString())).toEqual({
+      id: 'topic1',
+      schemaFilePath: topicFile1,
+      formatParts: { topic: 'topic1' },
+      bigQueryTableName: 'topic1',
+    });
+  });
+
+  it('should clean the directory during tear down', async () => {
+    await context.call(GooglePubSubWriteTopics, {});
+    const expectedAbsoluteDirectory = join(context.rootPath, expectedDirectory);
+    const existsAfterWrite = existsSync(expectedAbsoluteDirectory);
+
+    await context.call(GooglePubSubWriteTopics, { tearDown: true });
+    const existsAfterTearDown = existsSync(expectedAbsoluteDirectory);
+
+    expect(existsAfterWrite).toBeTrue();
+    expect(existsAfterTearDown).toBeFalse();
+  });
+});

--- a/src/functions/google-pubsub-write-topics.ts
+++ b/src/functions/google-pubsub-write-topics.ts
@@ -1,0 +1,118 @@
+import {
+  ProcessorResult,
+  WorkspaceContext,
+  WorkspaceFunction,
+} from '@causa/workspace';
+import {
+  EventTopicDefinition,
+  EventTopicList,
+  InfrastructureProcessor,
+} from '@causa/workspace-core';
+import { CAUSA_FOLDER } from '@causa/workspace/initialization';
+import { AllowMissing } from '@causa/workspace/validation';
+import { IsBoolean } from 'class-validator';
+import { mkdir, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { GoogleConfiguration } from '../configurations/index.js';
+
+/**
+ * The default directory where Pub/Sub topic configurations are written, relative to the workspace root.
+ */
+const DEFAULT_TOPIC_CONFIGURATIONS_DIRECTORY = join(
+  CAUSA_FOLDER,
+  'pubsub-topics',
+);
+
+/**
+ * A single Pub/Sub topic configuration, to be written to a JSON file.
+ */
+type TopicConfiguration = EventTopicDefinition & {
+  /**
+   * The name of the BigQuery table where events for this topic are stored.
+   */
+  readonly bigQueryTableName: string;
+};
+
+/**
+ * A function that uses {@link EventTopicList} to find all the topics in the workspace, and writes their configurations
+ * to a directory.
+ * The `google.pubSub.topicConfigurationsDirectory` configuration can be used to specify the output location of the
+ * topic configurations.
+ * This function returns a partial configuration, such that it can be used as a processor.
+ */
+export class GooglePubSubWriteTopics
+  extends WorkspaceFunction<Promise<ProcessorResult>>
+  implements InfrastructureProcessor
+{
+  @IsBoolean()
+  @AllowMissing()
+  readonly tearDown?: boolean;
+
+  /**
+   * Returns the path to the directory where Pub/Sub topic configurations should be written.
+   * It is either fetched from the workspace configuration, or the default value is used.
+   *
+   * @param context The {@link WorkspaceContext}.
+   * @returns The path to the directory where topic configurations should be written.
+   */
+  private getConfigurationsDirectory(context: WorkspaceContext): string {
+    return (
+      context
+        .asConfiguration<GoogleConfiguration>()
+        .get('google.pubSub.topicConfigurationsDirectory') ??
+      DEFAULT_TOPIC_CONFIGURATIONS_DIRECTORY
+    );
+  }
+
+  async _call(context: WorkspaceContext): Promise<ProcessorResult> {
+    const topicConfigurationsDirectory =
+      this.getConfigurationsDirectory(context);
+    const absoluteDir = join(context.rootPath, topicConfigurationsDirectory);
+
+    await rm(absoluteDir, { recursive: true, force: true });
+
+    if (this.tearDown) {
+      context.logger.debug(
+        `📫 Tore down Pub/Sub topic configurations directory '${absoluteDir}'.`,
+      );
+      return { configuration: {} };
+    }
+
+    context.logger.info(
+      '️📫 Listing and writing Pub/Sub topic configurations.',
+    );
+
+    const topics = await context.call(EventTopicList, {});
+
+    context.logger.debug(
+      `📫 Writing configurations for Pub/Sub topics: ${topics
+        .map((d) => `'${d.id}'`)
+        .join(', ')}.`,
+    );
+    await mkdir(absoluteDir, { recursive: true });
+    await Promise.all(
+      topics.map(async (topic) => {
+        const topicConfiguration: TopicConfiguration = {
+          ...topic,
+          bigQueryTableName: topic.id.replace(/[-\.]/g, '_'),
+        };
+        const topicFile = join(absoluteDir, `${topic.id}.json`);
+        await writeFile(topicFile, JSON.stringify(topicConfiguration));
+      }),
+    );
+
+    context.logger.debug(
+      `️📫 Wrote Pub/Sub topic configurations in '${absoluteDir}'.`,
+    );
+
+    return {
+      configuration: {
+        google: { pubSub: { topicConfigurationsDirectory } },
+      },
+    };
+  }
+
+  _supports(): boolean {
+    return true;
+  }
+}

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -14,6 +14,7 @@ import { GoogleFirebaseStorageMergeRules } from './google-firebase-storage-merge
 import { GoogleFirestoreMergeRules } from './google-firestore-merge-rules.js';
 import { GoogleIdentityPlatformGenerateCustomToken } from './google-identity-platform-generate-custom-token.js';
 import { GoogleIdentityPlatformGenerateToken } from './google-identity-platform-generate-token.js';
+import { GooglePubSubWriteTopics } from './google-pubsub-write-topics.js';
 import { GoogleServicesEnable } from './google-services-enable.js';
 import { GoogleSpannerListDatabases } from './google-spanner-list-databases.js';
 import { GoogleSpannerWriteDatabases } from './google-spanner-write-databases.js';
@@ -39,6 +40,7 @@ export function registerFunctions(context: ModuleRegistrationContext) {
     GoogleFirestoreMergeRules,
     GoogleIdentityPlatformGenerateCustomToken,
     GoogleIdentityPlatformGenerateToken,
+    GooglePubSubWriteTopics,
     GoogleServicesEnable,
     GoogleSpannerListDatabases,
     GoogleSpannerWriteDatabases,


### PR DESCRIPTION
This PR implements the `GooglePubSubWriteTopics` workspace function, which is also an infrastructure processor.

Its purpose is to generate a configuration file for each Pub/Sub topic that should be managed by the (to be implemented) Causa Pub/Sub Terraform module.

### Commits

- ✨ Implement the GooglePubSubWriteTopics function and processor
- 📝 Update changelog
- 📝 Update documentation