### PR TITLE
✨ Spanner-related configuration and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ The Google module provides several infrastructure processors, which can be used 
 
 Although infrastructure as code tools usually expose this feature as well (e.g. the [`google_project_service`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_service) Terraform resource), it might be more convenient to enable all the required services before running those tools. It avoids having to define dependencies between the services and all the actual resources being deployed.
 
+### `GoogleSpannerWriteDatabases`
+
+[GoogleSpannerWriteDatabases](./src/functions/google-spanner-write-databases.ts) writes a configuration file for each Spanner database, such that it can be picked up by the Causa Spanner Terraform module. This allows automatic setup of Spanner databases and their DDLs.
+
 ### `GooglePubSubWriteTopics`
 
 [GooglePubSubWriteTopics](./src/functions/google-pubsub-write-topics.ts) writes a configuration file for each event topic, such that it can be picked up by the Causa Pub/Sub Terraform module. This allows automatic setup of Pub/Sub topics, and optionally of the corresponding BigQuery tables.

--- a/src/configurations/google.ts
+++ b/src/configurations/google.ts
@@ -212,6 +212,28 @@ export type GoogleConfiguration = {
       };
 
       /**
+       * Configuration for the Spanner instance.
+       */
+      readonly instance?: {
+        /**
+         * The name of the Spanner instance.
+         */
+        readonly name?: string;
+
+        /**
+         * The instance geographic configuration.
+         * See https://cloud.google.com/spanner/docs/instance-configurations for more details.
+         */
+        readonly configuration?: string;
+
+        /**
+         * The compute capacity of the instance.
+         * See https://cloud.google.com/spanner/docs/compute-capacity for more details.
+         */
+        readonly processingUnits?: number;
+      };
+
+      /**
        * Defines how DDLs are found for the Spanner databases in the workspace.
        */
       readonly ddls?: {

--- a/src/functions/google-spanner-write-databases.spec.ts
+++ b/src/functions/google-spanner-write-databases.spec.ts
@@ -74,22 +74,22 @@ describe('GoogleSpannerWriteDatabases', () => {
         },
       },
     });
-    const actualDb1ConfigurationStr = await readFile(
+    const actualDb1ConfigurationBuffer = await readFile(
       join(context.rootPath, expectedDirectory, 'db1.json'),
     );
     const actualDb1Configuration = JSON.parse(
-      actualDb1ConfigurationStr.toString(),
+      actualDb1ConfigurationBuffer.toString(),
     );
     expect(actualDb1Configuration).toEqual({
       id: 'db1',
       ddls: ['CREATE TABLE a', 'ALTER TABLE a1', 'ALTER TABLE a2'],
       ddlFiles: [db1File1, db1File2],
     });
-    const actualDb2ConfigurationStr = await readFile(
+    const actualDb2ConfigurationBuffer = await readFile(
       join(context.rootPath, expectedDirectory, 'db2.json'),
     );
     const actualDb2Configuration = JSON.parse(
-      actualDb2ConfigurationStr.toString(),
+      actualDb2ConfigurationBuffer.toString(),
     );
     expect(actualDb2Configuration).toEqual({
       id: 'db2',
@@ -132,11 +132,11 @@ describe('GoogleSpannerWriteDatabases', () => {
         },
       },
     });
-    const actualDb1ConfigurationStr = await readFile(
+    const actualDb1ConfigurationBuffer = await readFile(
       join(context.rootPath, expectedDirectory, 'db1.json'),
     );
     const actualDb1Configuration = JSON.parse(
-      actualDb1ConfigurationStr.toString(),
+      actualDb1ConfigurationBuffer.toString(),
     );
     expect(actualDb1Configuration).toEqual({
       id: 'db1',


### PR DESCRIPTION
This PR defines new configuration fields, meant to be used by the Causa Spanner Terraform module.
It also makes minor improvements to the `GooglePubSubWriteTopics` processor.

### Commits

- ✨ Define configuration fields for the Spanner instance
- ✨ Always clean the Spanner database configurations directory before writing files
- 📝 Document the GooglePubSubWriteTopics infrastructure processor