### PR TITLE
✨ `google.accessToken` secret backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Make `GoogleApisService.projectId` possibly undefined (instead of throwing when it is not set in the configuration).
+
+Features:
+
+- Implement the `google.accessToken` secret backend, which returns an access token for the current GCP user or service account.
+
 Fixes:
 
 - Ensure the Spanner client is closed.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ secrets:
 
 When the GCP project is not specified in the secret ID, it is inferred from `google.secretManager.project`, or `google.project` (in this order). This allows defining the GCP project a single time if needed.
 
+A second secret backend, `google.accessToken`, does not fetch secrets from a source but rather returns a GCP access token, which can be used to access Google services:
+
+```yaml
+secrets:
+  gcpAccessToken:
+    backend: google.accessToken
+```
+
 ## 🔨 Custom `google` commands
 
 This modules adds a new command to the CLI: `cs google`. Here is the list of subcommands that are exposed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "firebase": "^10.4.0",
         "firebase-admin": "^11.11.0",
         "globby": "^13.2.2",
+        "google-auth-library": "^9.0.0",
         "googleapis": "^126.0.1",
         "pino": "^8.15.1",
         "uuid": "^9.0.1"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "firebase": "^10.4.0",
     "firebase-admin": "^11.11.0",
     "globby": "^13.2.2",
+    "google-auth-library": "^9.0.0",
     "googleapis": "^126.0.1",
     "pino": "^8.15.1",
     "uuid": "^9.0.1"

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -39,7 +39,10 @@ import {
   ProjectGetArtefactDestinationForCloudRun,
   ProjectPushArtefactForCloudFunctions,
 } from './project/index.js';
-import { SecretFetchForGoogleSecretManager } from './secret/index.js';
+import {
+  SecretFetchForGoogleAccessToken,
+  SecretFetchForGoogleSecretManager,
+} from './secret/index.js';
 
 export function registerFunctions(context: ModuleRegistrationContext) {
   context.registerFunctionImplementations(
@@ -73,6 +76,7 @@ export function registerFunctions(context: ModuleRegistrationContext) {
     ProjectGetArtefactDestinationForCloudFunctions,
     ProjectGetArtefactDestinationForCloudRun,
     ProjectPushArtefactForCloudFunctions,
+    SecretFetchForGoogleAccessToken,
     SecretFetchForGoogleSecretManager,
   );
 }

--- a/src/functions/secret/fetch-access-token.spec.ts
+++ b/src/functions/secret/fetch-access-token.spec.ts
@@ -1,0 +1,63 @@
+import { SecretBackendNotFoundError, WorkspaceContext } from '@causa/workspace';
+import { createContext } from '@causa/workspace/testing';
+import { jest } from '@jest/globals';
+import 'jest-extended';
+import { GoogleApisService } from '../../services/index.js';
+import {
+  AuthClientResponseError,
+  SecretFetchForGoogleAccessToken,
+} from './fetch-access-token.js';
+
+describe('SecretFetchForGoogleAccessToken', () => {
+  let context: WorkspaceContext;
+  let googleApisService: GoogleApisService;
+
+  beforeEach(() => {
+    ({ context } = createContext({
+      configuration: {
+        workspace: { name: '🏷️' },
+        secrets: {
+          gcpAccessToken: { backend: 'google.accessToken' },
+          notGoogle: { backend: '❌' },
+        },
+      },
+      functions: [SecretFetchForGoogleAccessToken],
+    }));
+    googleApisService = context.service(GoogleApisService);
+  });
+
+  it('should not handle secrets with other backends', async () => {
+    const actualPromise = context.secret('notGoogle');
+
+    await expect(actualPromise).rejects.toThrow(SecretBackendNotFoundError);
+  });
+
+  it('should return an error if the auth client does not return a token', async () => {
+    const getAccessToken = jest.fn(() => Promise.resolve({}));
+    jest.spyOn(googleApisService, 'getAuthClient').mockResolvedValue({
+      getAccessToken,
+    } as any);
+
+    const actualPromise = context.secret('gcpAccessToken');
+
+    await expect(actualPromise).rejects.toThrow(AuthClientResponseError);
+    expect(googleApisService.getAuthClient).toHaveBeenCalledExactlyOnceWith();
+    expect(getAccessToken).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('should return an access token', async () => {
+    const expectedSecret = '🗝️';
+    const getAccessToken = jest.fn(() =>
+      Promise.resolve({ token: expectedSecret }),
+    );
+    jest.spyOn(googleApisService, 'getAuthClient').mockResolvedValue({
+      getAccessToken,
+    } as any);
+
+    const actualSecret = await context.secret('gcpAccessToken');
+
+    expect(actualSecret).toEqual(expectedSecret);
+    expect(googleApisService.getAuthClient).toHaveBeenCalledExactlyOnceWith();
+    expect(getAccessToken).toHaveBeenCalledExactlyOnceWith();
+  });
+});

--- a/src/functions/secret/fetch-access-token.ts
+++ b/src/functions/secret/fetch-access-token.ts
@@ -1,0 +1,37 @@
+import { SecretFetch, WorkspaceContext } from '@causa/workspace';
+import { GoogleApisService } from '../../services/index.js';
+
+/**
+ * An error thrown when the auth client does not return a token.
+ */
+export class AuthClientResponseError extends Error {
+  constructor() {
+    super(
+      'Failed to retrieve the Google access token from the auth client response.',
+    );
+  }
+}
+
+/**
+ * Implements {@link SecretFetch} to retrieve a Google access token.
+ * This backend does not require any configuration, as it does not fetch a specific secret and can only return a single
+ * value. A Google access token can be used to authenticate with other Google services. The returned token is configured
+ * with the current user (or service account)'s credentials, and for the configured GCP project (if any).
+ * The backend ID is `google.accessToken`.
+ */
+export class SecretFetchForGoogleAccessToken extends SecretFetch {
+  async _call(context: WorkspaceContext): Promise<string> {
+    const authClient = await context.service(GoogleApisService).getAuthClient();
+    const { token } = await authClient.getAccessToken();
+
+    if (!token) {
+      throw new AuthClientResponseError();
+    }
+
+    return token;
+  }
+
+  _supports(): boolean {
+    return this.backend === 'google.accessToken';
+  }
+}

--- a/src/functions/secret/index.ts
+++ b/src/functions/secret/index.ts
@@ -1,1 +1,2 @@
+export { SecretFetchForGoogleAccessToken } from './fetch-access-token.js';
 export { SecretFetchForGoogleSecretManager } from './fetch-secret-manager.js';

--- a/src/services/google-apis.ts
+++ b/src/services/google-apis.ts
@@ -1,4 +1,5 @@
 import { WorkspaceContext } from '@causa/workspace';
+import { AuthClient } from 'google-auth-library';
 import { GoogleApis, google } from 'googleapis';
 import { GoogleConfiguration } from '../configurations/index.js';
 import { ApiClient, OptionsOfApiClient } from './google-apis.types.js';
@@ -11,24 +12,25 @@ export class GoogleApisService {
   /**
    * The GCP project ID read from the {@link WorkspaceContext} configuration.
    */
-  readonly projectId: string;
+  readonly projectId: string | undefined;
 
   constructor(context: WorkspaceContext) {
-    const googleConf = context.asConfiguration<GoogleConfiguration>();
-    this.projectId = googleConf.getOrThrow('google.project');
+    this.projectId = context
+      .asConfiguration<GoogleConfiguration>()
+      .get('google.project');
   }
 
   /**
    * The promise returning the `JSONClient` configured with the {@link GoogleApisService.projectId}.
    */
-  private authClientPromise: Promise<any> | undefined;
+  private authClientPromise: Promise<AuthClient> | undefined;
 
   /**
    * Possibly initializes and returns the auth client to use with Google API clients.
    *
    * @returns The auth client.
    */
-  async getAuthClient(): Promise<any> {
+  async getAuthClient(): Promise<AuthClient> {
     if (!this.authClientPromise) {
       const auth = new google.auth.GoogleAuth({
         projectId: this.projectId,


### PR DESCRIPTION
This PR implements the `google.accessToken` secret backend. This backend does not fetch secrets from a provider and always returns a similar value: a GCP access token.
The GCP access token is generated using the currently configured client, meaning with the current user or service account. If the `google.project` configuration is set, it is also used.

### Commits

- ➕ Depend on google-auth-library
- 💥 Make GoogleApisService.projectId possibly undefined and type getAuthClient response
- ✨ Implement SecretFetch for Google access tokens
- 📝 Update changelog
- 📝 Document the google.accessToken secret backend