### PR TITLE
🔖 Prepare v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.6.0 (2023-09-29)
+
 Breaking changes:
 
 - Make `GoogleApisService.projectId` possibly undefined (instead of throwing when it is not set in the configuration).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-google",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.4.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "The Causa workspace module providing many functionalities related to GCP and its services.",
   "repository": "github:causa-io/workspace-module-google",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Make `GoogleApisService.projectId` possibly undefined (instead of throwing when it is not set in the configuration).

Features:

- Implement the `google.accessToken` secret backend, which returns an access token for the current GCP user or service account.

Fixes:

- Ensure the Spanner client is closed.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.6.0