### PR TITLE
🔖 Prepare v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.7.1 (2024-02-22)
+
 Fixes:
 
 - Set `@google-cloud/spanner` and `google-gax` versions to avoid dependency issues.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-google",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.4.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "The Causa workspace module providing many functionalities related to GCP and its services.",
   "repository": "github:causa-io/workspace-module-google",
   "license": "ISC",


### PR DESCRIPTION
Fixes:

- Set `@google-cloud/spanner` and `google-gax` versions to avoid dependency issues.

### Commits

- **📝 Update changelog**
- **🔖 Set version to 0.7.1**