### PR TITLE
🔖 Prepare v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.7.2 (2024-02-26)
+
 Fixes:
 
 - Log emitted Spanner database errors as warnings. These errors can occur when setting up the Spanner emulator and can safely be ignored.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-google",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.4.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "The Causa workspace module providing many functionalities related to GCP and its services.",
   "repository": "github:causa-io/workspace-module-google",
   "license": "ISC",


### PR DESCRIPTION
Fixes:

- Log emitted Spanner database errors as warnings. These errors can occur when setting up the Spanner emulator and can safely be ignored.

### Commits

- **📝 Update changelog**
- **🔖 Set version to 0.7.2**