### PR TITLE
🔖 Prepare v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.8.1 (2024-05-22)
+
 Chore:
 
 - Upgrade dependencies, including `@google-cloud/secret-manager` above its buggy releases.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-google",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.5.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "The Causa workspace module providing many functionalities related to GCP and its services.",
   "repository": "github:causa-io/workspace-module-google",
   "license": "ISC",


### PR DESCRIPTION
Chore:

- Upgrade dependencies, including `@google-cloud/secret-manager` above its buggy releases.

### Commits

- **🔖 Set version to 0.8.1**
- **📝 Update changelog**