### PR TITLE
🔖 Prepare v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.9.0 (2024-05-27)
+
 Breaking changes:
 
 - Ignore symbolic links when listing Firebase security rules files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-google",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.5.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "The Causa workspace module providing many functionalities related to GCP and its services.",
   "repository": "github:causa-io/workspace-module-google",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Ignore symbolic links when listing Firebase security rules files.

### Commits

- **🔖 Set version to 0.9.0**
- **📝 Update changelog**