### PR TITLE
🐛 Set the project ID when initializing the Pub/Sub client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Set the project ID when initializing the Pub/Sub client.
+
 Chores:
 
 - Adapt to `quicktype` breaking changes.

--- a/src/services/pubsub.spec.ts
+++ b/src/services/pubsub.spec.ts
@@ -18,6 +18,12 @@ describe('PubSubService', () => {
     service = context.service(PubSubService);
   });
 
+  describe('pubSub', () => {
+    it('should configure the Pub/Sub client with the project ID', () => {
+      expect(service.pubSub.projectId).toEqual('my-project');
+    });
+  });
+
   describe('getGcpServiceAccount', () => {
     it('should return the service account email', async () => {
       jest

--- a/src/services/pubsub.ts
+++ b/src/services/pubsub.ts
@@ -24,11 +24,11 @@ export class PubSubService {
   readonly projectId: string;
 
   constructor(context: WorkspaceContext) {
-    this.pubSub = new PubSub();
     this.resourceManagerService = context.service(ResourceManagerService);
     this.projectId = context
       .asConfiguration<GoogleConfiguration>()
       .getOrThrow('google.project');
+    this.pubSub = new PubSub({ projectId: this.projectId });
   }
 
   /**


### PR DESCRIPTION
This could cause issues in some cases, e.g. when backfilling events.

### Commits

- **🐛 Set the project ID when initializing the Pub/Sub client**
- **📝 Update changelog**