### PR TITLE
🔖 Prepare v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.9.3 (2025-05-12)
+
 Fixes:
 
 - Set the project ID when initializing the Pub/Sub client.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-google",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.6.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "The Causa workspace module providing many functionalities related to GCP and its services.",
   "repository": "github:causa-io/workspace-module-google",
   "license": "ISC",


### PR DESCRIPTION
Fixes:

- Set the project ID when initializing the Pub/Sub client.

Chores:

- Adapt to `quicktype` breaking changes.

### Commits

- **🔖 Set version to 0.9.3**
- **📝 Update changelog**