### PR TITLE
🏷️ Refine configuration schemas with known values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Refine configuration schemas with known `events.broker`, `serviceContainer.platform`, `serverlessFunctions.platform`, `infrastructure.processors`, and `secrets` backend values.
+
 ## v0.13.0 (2026-02-11)
 
 Same as release candidates.

--- a/src/configurations/generated.ts
+++ b/src/configurations/generated.ts
@@ -10,6 +10,30 @@ import {
   IsString,
 } from 'class-validator';
 
+export class Events {
+  constructor(init: Events) {
+    Object.assign(this, init);
+  }
+
+  @AllowMissing()
+  @IsString()
+  readonly broker?: string;
+  [property: string]: any;
+}
+
+/**
+ * Google-specific refinement of the events configuration.
+ */
+export class GoogleEventsConfiguration {
+  constructor(init: GoogleEventsConfiguration) {
+    Object.assign(this, init);
+  }
+
+  @AllowMissing()
+  readonly events?: Events;
+  [property: string]: any;
+}
+
 /**
  * The Cloud Storage configuration where Cloud Functions archives should be uploaded.
  */
@@ -872,6 +896,117 @@ export class GoogleConfiguration {
   [property: string]: any;
 }
 
+/**
+ * Merges all Firebase Storage security rules from the workspace.
+ * Sets the `google.firebaseStorage.securityRuleFile` configuration value.
+ */
+export class GoogleProcessor {
+  constructor(init: GoogleProcessor) {
+    Object.assign(this, init);
+  }
+
+  @IsString()
+  readonly name!: string;
+  [property: string]: any;
+}
+
+export class Infrastructure {
+  constructor(init: Infrastructure) {
+    Object.assign(this, init);
+  }
+
+  @AllowMissing()
+  @IsArray()
+  readonly processors?: GoogleProcessor[];
+  [property: string]: any;
+}
+
+/**
+ * Google-specific refinement of the infrastructure configuration with known processors.
+ */
+export class GoogleInfrastructureConfiguration {
+  constructor(init: GoogleInfrastructureConfiguration) {
+    Object.assign(this, init);
+  }
+
+  @AllowMissing()
+  readonly infrastructure?: Infrastructure;
+  [property: string]: any;
+}
+
+export class Secrets {
+  constructor(init: Secrets) {
+    Object.assign(this, init);
+  }
+
+  @AllowMissing()
+  @IsString()
+  readonly defaultBackend?: string;
+  [property: string]: any;
+}
+
+export class Causa {
+  constructor(init: Causa) {
+    Object.assign(this, init);
+  }
+
+  @AllowMissing()
+  readonly secrets?: Secrets;
+  [property: string]: any;
+}
+
+export class Secret {
+  constructor(init: Secret) {
+    Object.assign(this, init);
+  }
+
+  @AllowMissing()
+  @IsString()
+  readonly backend?: string;
+  [property: string]: any;
+}
+
+/**
+ * Google-specific refinement of the secrets configuration.
+ */
+export class GoogleSecretsConfiguration {
+  constructor(init: GoogleSecretsConfiguration) {
+    Object.assign(this, init);
+  }
+
+  @AllowMissing()
+  readonly causa?: Causa;
+
+  @AllowMissing()
+  @IsObject()
+  readonly secrets?: { [key: string]: Secret };
+  [property: string]: any;
+}
+
+export class ServerlessFunctions {
+  constructor(init: ServerlessFunctions) {
+    Object.assign(this, init);
+  }
+
+  @AllowMissing()
+  @IsString()
+  readonly platform?: string;
+  [property: string]: any;
+}
+
+/**
+ * Google-specific refinement of the serverless functions configuration.
+ */
+export class GoogleServerlessFunctionsConfiguration {
+  constructor(init: GoogleServerlessFunctionsConfiguration) {
+    Object.assign(this, init);
+  }
+
+  @AllowMissing()
+  readonly serverlessFunctions?: ServerlessFunctions;
+  [property: string]: any;
+}
+
 export class Outputs {
   constructor(init: Outputs) {
     Object.assign(this, init);
@@ -1154,6 +1289,10 @@ export class ServiceContainer {
 
   @AllowMissing()
   readonly outputs?: Outputs;
+
+  @AllowMissing()
+  @IsString()
+  readonly platform?: string;
 
   /**
    * A map of triggers that call the service's endpoints when they occur.

--- a/src/configurations/schemas/events.yaml
+++ b/src/configurations/schemas/events.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://json-schema.org/draft-07/schema
+
+title: GoogleEventsConfiguration
+type: object
+description: Google-specific refinement of the events configuration.
+properties:
+  events:
+    type: object
+    properties:
+      broker:
+        anyOf:
+          - type: string
+
+          - title: GooglePubSubBroker
+            type: string
+            enum:
+              - google.pubSub
+            description: Google Pub/Sub message broker.

--- a/src/configurations/schemas/infrastructure.yaml
+++ b/src/configurations/schemas/infrastructure.yaml
@@ -1,0 +1,82 @@
+# yaml-language-server: $schema=https://json-schema.org/draft-07/schema
+
+title: GoogleInfrastructureConfiguration
+type: object
+description: Google-specific refinement of the infrastructure configuration with known processors.
+properties:
+  infrastructure:
+    type: object
+    properties:
+      processors:
+        type: array
+        items:
+          anyOf:
+            - type: object
+              properties:
+                name:
+                  type: string
+              required:
+                - name
+
+            - title: GoogleServicesEnableProcessor
+              type: object
+              description: Enables GCP services defined in the `google.services` configuration.
+              properties:
+                name:
+                  type: string
+                  enum:
+                    - GoogleServicesEnable
+              required:
+                - name
+
+            - title: GooglePubSubWriteTopicsProcessor
+              type: object
+              description: |-
+                Writes Pub/Sub topic configurations to JSON files.
+                Sets the `google.pubSub.topicConfigurationsDirectory` configuration value.
+              properties:
+                name:
+                  type: string
+                  enum:
+                    - GooglePubSubWriteTopics
+              required:
+                - name
+
+            - title: GoogleSpannerWriteDatabasesProcessor
+              type: object
+              description: |-
+                Writes Spanner database configurations to JSON files.
+                Sets the `google.spanner.databaseConfigurationsDirectory` configuration value.
+              properties:
+                name:
+                  type: string
+                  enum:
+                    - GoogleSpannerWriteDatabases
+              required:
+                - name
+
+            - title: GoogleFirestoreMergeRulesProcessor
+              type: object
+              description: |-
+                Merges all Firestore security rules from the workspace.
+                Sets the `google.firestore.securityRuleFile` configuration value.
+              properties:
+                name:
+                  type: string
+                  enum:
+                    - GoogleFirestoreMergeRules
+              required:
+                - name
+
+            - title: GoogleFirebaseStorageMergeRulesProcessor
+              type: object
+              description: |-
+                Merges all Firebase Storage security rules from the workspace.
+                Sets the `google.firebaseStorage.securityRuleFile` configuration value.
+              properties:
+                name:
+                  type: string
+                  enum:
+                    - GoogleFirebaseStorageMergeRules
+              required:
+                - name

--- a/src/configurations/schemas/secrets.yaml
+++ b/src/configurations/schemas/secrets.yaml
@@ -1,0 +1,58 @@
+# yaml-language-server: $schema=https://json-schema.org/draft-07/schema
+
+title: GoogleSecretsConfiguration
+type: object
+description: Google-specific refinement of the secrets configuration.
+properties:
+  causa:
+    type: object
+    properties:
+      secrets:
+        type: object
+        properties:
+          defaultBackend:
+            anyOf:
+              - type: string
+
+              - title: GoogleSecretManagerBackend
+                type: string
+                enum:
+                  - google.secretManager
+                description: Google Secret Manager backend.
+
+  secrets:
+    type: object
+    additionalProperties:
+      anyOf:
+        - type: object
+          properties:
+            backend:
+              type: string
+
+        - title: GoogleSecretManagerSecretConfiguration
+          type: object
+          description: A secret stored in Google Secret Manager.
+          properties:
+            backend:
+              type: string
+              enum:
+                - google.secretManager
+
+            id:
+              type: string
+              description: |-
+                The reference to the secret in Google Secret Manager.
+                Supported formats: `<secret-name>`, `projects/<project>/secrets/<secret-name>`, `projects/<project>/secrets/<secret-name>/versions/<version>`.
+                If the project is not specified, `google.secretManager.project` or `google.project` will be used.
+                If the version is not specified, `latest` will be used.
+
+        - title: GoogleAccessTokenSecretConfiguration
+          type: object
+          description: |-
+            A secret that returns a Google access token for the current user or service account.
+            This backend does not require any additional configuration.
+          properties:
+            backend:
+              type: string
+              enum:
+                - google.accessToken

--- a/src/configurations/schemas/serverless-functions.yaml
+++ b/src/configurations/schemas/serverless-functions.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://json-schema.org/draft-07/schema
+
+title: GoogleServerlessFunctionsConfiguration
+type: object
+description: Google-specific refinement of the serverless functions configuration.
+properties:
+  serverlessFunctions:
+    type: object
+    properties:
+      platform:
+        anyOf:
+          - type: string
+
+          - title: GoogleCloudFunctionsPlatform
+            type: string
+            enum:
+              - google.cloudFunctions
+            description: Google Cloud Functions platform.

--- a/src/configurations/schemas/service-container.yaml
+++ b/src/configurations/schemas/service-container.yaml
@@ -7,6 +7,16 @@ properties:
   serviceContainer:
     type: object
     properties:
+      platform:
+        anyOf:
+          - type: string
+
+          - title: GoogleCloudRunPlatform
+            type: string
+            enum:
+              - google.cloudRun
+            description: Google Cloud Run platform.
+
       triggers:
         type: object
         description: A map of triggers that call the service's endpoints when they occur.

--- a/src/functions/causa/list-schemas.spec.ts
+++ b/src/functions/causa/list-schemas.spec.ts
@@ -15,8 +15,12 @@ describe('CausaListConfigurationSchemasForGoogle', () => {
 
     const actualBaseNames = actualSchemas.map((s) => basename(s));
     expect(actualBaseNames).toIncludeSameMembers([
+      'events.yaml',
       'google.yaml',
-      'service-container-cloud-run.yaml',
+      'infrastructure.yaml',
+      'secrets.yaml',
+      'serverless-functions.yaml',
+      'service-container.yaml',
     ]);
   });
 });


### PR DESCRIPTION
### 📝 Description of the PR

- Add `events.yaml` schema refining `events.broker` with `google.pubSub`.
- Add `serverless-functions.yaml` schema refining `serverlessFunctions.platform` with `google.cloudFunctions`.
- Add `serviceContainer.platform` refinement with `google.cloudRun` to the service container schema.
- Add `infrastructure.yaml` schema enumerating known Google infrastructure processors: `GoogleServicesEnable`, `GooglePubSubWriteTopics`, `GoogleSpannerWriteDatabases`, `GoogleFirestoreMergeRules`, `GoogleFirebaseStorageMergeRules`.
- Add `secrets.yaml` schema refining secret backends with `google.secretManager` (including `id` property) and `google.accessToken`.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.