### PR TITLE
🐛 Define `vpcAccessConnectorEgressSettings` enum values as upper snake case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Remove support for Node.js 20.
+
+Fixes:
+
+- Define `vpcAccessConnectorEgressSettings` enum values as upper snake case.
+
 ## v0.14.1 (2026-03-16)
 
 Chore:

--- a/src/configurations/generated.ts
+++ b/src/configurations/generated.ts
@@ -89,8 +89,8 @@ export enum GoogleCloudRunIngress {
  * See https://cloud.google.com/run/docs/configuring/connecting-vpc#manage for more details.
  */
 export enum GoogleCloudRunVpcAccessConnectorEgressSettings {
-  AllTraffic = 'all-traffic',
-  PrivateRangesOnly = 'private-ranges-only',
+  AllTraffic = 'ALL_TRAFFIC',
+  PrivateRangesOnly = 'PRIVATE_RANGES_ONLY',
 }
 
 /**
@@ -171,7 +171,7 @@ export class GoogleCloudRun {
    * See https://cloud.google.com/run/docs/configuring/connecting-vpc#manage for more details.
    */
   @AllowMissing()
-  @IsIn(['all-traffic', 'private-ranges-only'])
+  @IsIn(['ALL_TRAFFIC', 'PRIVATE_RANGES_ONLY'])
   readonly vpcAccessConnectorEgressSettings?: GoogleCloudRunVpcAccessConnectorEgressSettings;
   [property: string]: any;
 }
@@ -955,14 +955,28 @@ export class Causa {
   [property: string]: any;
 }
 
-export class Secret {
-  constructor(init: Secret) {
+/**
+ * A secret that returns a Google access token for the current user or service account.
+ * This backend does not require any additional configuration.
+ */
+export class GoogleSecretConfiguration {
+  constructor(init: GoogleSecretConfiguration) {
     Object.assign(this, init);
   }
 
   @AllowMissing()
   @IsString()
   readonly backend?: string;
+
+  /**
+   * The reference to the secret in Google Secret Manager.
+   * Supported formats: `<secret-name>`, `projects/<project>/secrets/<secret-name>`, `projects/<project>/secrets/<secret-name>/versions/<version>`.
+   * If the project is not specified, `google.secretManager.project` or `google.project` will be used.
+   * If the version is not specified, `latest` will be used.
+   */
+  @AllowMissing()
+  @IsString()
+  readonly id?: string;
   [property: string]: any;
 }
 
@@ -979,7 +993,7 @@ export class GoogleSecretsConfiguration {
 
   @AllowMissing()
   @IsObject()
-  readonly secrets?: { [key: string]: Secret };
+  readonly secrets?: { [key: string]: GoogleSecretConfiguration };
   [property: string]: any;
 }
 

--- a/src/configurations/schemas/google.yaml
+++ b/src/configurations/schemas/google.yaml
@@ -375,8 +375,8 @@ properties:
             title: GoogleCloudRunVpcAccessConnectorEgressSettings
             type: string
             enum:
-              - all-traffic
-              - private-ranges-only
+              - ALL_TRAFFIC
+              - PRIVATE_RANGES_ONLY
             description: |-
               The setting for egress traffic that goes through the VPC access connector.
               See https://cloud.google.com/run/docs/configuring/connecting-vpc#manage for more details.


### PR DESCRIPTION
### 📝 Description of the PR

The title says it all. Those values are passed directly to the GCP API, and should match the values accepted by the API.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~