### PR TITLE
🔖 Prepare v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.15.0 (2026-04-13)
+
 Breaking changes:
 
 - Remove support for Node.js 20.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-google",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.7.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "The Causa workspace module providing many functionalities related to GCP and its services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Breaking changes:

- Remove support for Node.js 20.

Fixes:

- Define `vpcAccessConnectorEgressSettings` enum values as upper snake case.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~