### PR TITLE
🔖 Prepare v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.16.0 (2026-04-21)
+
 Breaking changes:
 
 - Align with `@causa/workspace-core`'s async-iterable backfilling contract. Drop the `BigQueryEventsSource` and `PubSubBackfillEventPublisher` classes (and the `./backfilling` subpath), replaced by the `EventTopicCreateBackfillSourceForBigQuery` workspace function and inlined Pub/Sub publishing in `EventTopicBrokerPublishEventsForGoogle`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-google",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.7.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "The Causa workspace module providing many functionalities related to GCP and its services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Breaking changes:

- Align with `@causa/workspace-core`'s async-iterable backfilling contract. Drop the `BigQueryEventsSource` and `PubSubBackfillEventPublisher` classes (and the `./backfilling` subpath), replaced by the `EventTopicCreateBackfillSourceForBigQuery` workspace function and inlined Pub/Sub publishing in `EventTopicBrokerPublishEventsForGoogle`.
- Support the new project-scoped trigger format in `EventTopicBrokerCreateTriggerForCloudRun`, on top of the existing URI string.

Features:

- Add the `google.cloudRun.eventBackfillServiceName` configuration, overriding the Cloud Run service targeted by project-scoped backfill triggers.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~