### PR TITLE
🔖 Prepare v0.18.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.18.0-beta.1 (2026-05-19)
+
 Features:
 
 - Implement `ModelSchemaExtractDatabase` for the `google.spanner` and `google.firestore` engines, deriving database bindings from the `googleSpannerTable` and `googleFirestoreCollection` Causa extensions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.17.0",
+  "version": "0.18.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-google",
-      "version": "0.17.0",
+      "version": "0.18.0-beta.1",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.8.0-beta.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.17.0",
+  "version": "0.18.0-beta.1",
   "description": "The Causa workspace module providing many functionalities related to GCP and its services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Features:

- Implement `ModelSchemaExtractDatabase` for the `google.spanner` and `google.firestore` engines, deriving database bindings from the `googleSpannerTable` and `googleFirestoreCollection` Causa extensions.

Chore:

- Adapt to `@causa/workspace`'s removal of the `context` argument from `_call` and `_supports`. The context is now read from `this._context` in all function implementations and deferred calls.
- Adapt to `@causa/workspace-core`'s removal of `BackfillEvent.key`. The Pub/Sub publisher no longer forwards an ordering key.
- Replace `js-yaml` with `yaml` in the schema transformation script.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~