### PR TITLE
🔖 Prepare v0.18.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.18.0-beta.2 (2026-05-22)
+
 Breaking changes:
 
 - Rewrite the `TypeScriptGetDecoratorRendererForGoogleFirestore` and `TypeScriptGetDecoratorRendererForGoogleSpanner` workspace functions (and the underlying `GoogleFirestoreRenderer` / `GoogleSpannerRenderer` classes) as `ModelGenerateTypeScriptDecoratorsForGoogleFirestore` and `ModelGenerateTypeScriptDecoratorsForGoogleSpanner`, following the `@causa/workspace-typescript` breaking change that replaces `TypeScriptGetDecoratorRenderer` with the schema-based `ModelGenerateTypeScriptDecorators` function.

--- a/causa.yaml
+++ b/causa.yaml
@@ -26,7 +26,7 @@ model:
 javascript:
   dependencies:
     check:
-      allowlist: [GHSA-vpq2-c234-7xj6]
+      allowlist: [GHSA-w5hq-g745-h8pq]
     update:
       packageTargets:
         "@types/node": minor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.18.0-beta.1",
+  "version": "0.18.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-google",
-      "version": "0.18.0-beta.1",
+      "version": "0.18.0-beta.2",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.8.0-beta.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.18.0-beta.1",
+  "version": "0.18.0-beta.2",
   "description": "The Causa workspace module providing many functionalities related to GCP and its services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Breaking changes:

- Rewrite the `TypeScriptGetDecoratorRendererForGoogleFirestore` and `TypeScriptGetDecoratorRendererForGoogleSpanner` workspace functions (and the underlying `GoogleFirestoreRenderer` / `GoogleSpannerRenderer` classes) as `ModelGenerateTypeScriptDecoratorsForGoogleFirestore` and `ModelGenerateTypeScriptDecoratorsForGoogleSpanner`, following the `@causa/workspace-typescript` breaking change that replaces `TypeScriptGetDecoratorRenderer` with the schema-based `ModelGenerateTypeScriptDecorators` function.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~