### PR TITLE
✨ Support custom emulator ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Add the `google.firestore.emulator.port`, `google.pubSub.emulator.port`, `google.firebaseStorage.emulator.port`, `google.identityPlatform.emulator.port`, `google.spanner.emulator.grpcPort`, and `google.spanner.emulator.httpPort` configurations to override the host ports bound by the emulators, enabling several workspaces to run their emulators in parallel on the same machine.
+
 ## v0.18.0-beta.2 (2026-05-22)
 
 Breaking changes:

--- a/src/configurations/generated.ts
+++ b/src/configurations/generated.ts
@@ -274,6 +274,14 @@ export class GoogleFirebaseStorageEmulator {
   @AllowMissing()
   @IsString()
   readonly containerName?: string;
+
+  /**
+   * The host port to which the Firebase Storage emulator is bound.
+   * Override this to run several workspaces in parallel on the same machine. Defaults to `9199`.
+   */
+  @AllowMissing()
+  @IsNumber()
+  readonly port?: number;
   [property: string]: any;
 }
 
@@ -322,6 +330,14 @@ export class GoogleFirestoreEmulator {
   @AllowMissing()
   @IsString()
   readonly containerName?: string;
+
+  /**
+   * The host port to which the Firestore emulator is bound.
+   * Override this to run several workspaces in parallel on the same machine. Defaults to `8080`.
+   */
+  @AllowMissing()
+  @IsNumber()
+  readonly port?: number;
   [property: string]: any;
 }
 
@@ -388,6 +404,14 @@ export class GoogleIdentityPlatformEmulator {
   @AllowMissing()
   @IsString()
   readonly containerName?: string;
+
+  /**
+   * The host port to which the Identity Platform (Firebase Auth) emulator is bound.
+   * Override this to run several workspaces in parallel on the same machine. Defaults to `9099`.
+   */
+  @AllowMissing()
+  @IsNumber()
+  readonly port?: number;
   [property: string]: any;
 }
 
@@ -464,6 +488,14 @@ export class GooglePubSubEmulator {
   @AllowMissing()
   @IsString()
   readonly containerName?: string;
+
+  /**
+   * The host port to which the Pub/Sub emulator is bound.
+   * Override this to run several workspaces in parallel on the same machine. Defaults to `8085`.
+   */
+  @AllowMissing()
+  @IsNumber()
+  readonly port?: number;
   [property: string]: any;
 }
 
@@ -625,6 +657,22 @@ export class GoogleSpannerEmulator {
   @AllowMissing()
   @IsString()
   readonly containerName?: string;
+
+  /**
+   * The host port to which the Spanner emulator gRPC API is bound.
+   * Override this to run several workspaces in parallel on the same machine. Defaults to `9010`.
+   */
+  @AllowMissing()
+  @IsNumber()
+  readonly grpcPort?: number;
+
+  /**
+   * The host port to which the Spanner emulator HTTP API is bound.
+   * Override this to run several workspaces in parallel on the same machine. Defaults to `9020`.
+   */
+  @AllowMissing()
+  @IsNumber()
+  readonly httpPort?: number;
 
   /**
    * The name of the Spanner instance that will automatically be created in the emulator.

--- a/src/configurations/schemas/google.yaml
+++ b/src/configurations/schemas/google.yaml
@@ -113,6 +113,12 @@ properties:
                 type: string
                 description: The name of the local Docker container running the emulator.
 
+              port:
+                type: number
+                description: |-
+                  The host port to which the Firebase Storage emulator is bound.
+                  Override this to run several workspaces in parallel on the same machine. Defaults to `9199`.
+
           securityRuleFiles:
             type: array
             items:
@@ -137,6 +143,12 @@ properties:
                 type: string
                 description: The name of the local Docker container running the emulator.
 
+              port:
+                type: number
+                description: |-
+                  The host port to which the Identity Platform (Firebase Auth) emulator is bound.
+                  Override this to run several workspaces in parallel on the same machine. Defaults to `9099`.
+
       firestore:
         title: GoogleFirestore
         type: object
@@ -150,6 +162,12 @@ properties:
               containerName:
                 type: string
                 description: The name of the local Docker container running the emulator.
+
+              port:
+                type: number
+                description: |-
+                  The host port to which the Firestore emulator is bound.
+                  Override this to run several workspaces in parallel on the same machine. Defaults to `8080`.
 
           securityRuleFiles:
             type: array
@@ -174,6 +192,12 @@ properties:
               containerName:
                 type: string
                 description: The name of the local Docker container running the emulator.
+
+              port:
+                type: number
+                description: |-
+                  The host port to which the Pub/Sub emulator is bound.
+                  Override this to run several workspaces in parallel on the same machine. Defaults to `8085`.
 
           topicConfigurationsDirectory:
             type: string
@@ -223,6 +247,18 @@ properties:
               instanceName:
                 type: string
                 description: The name of the Spanner instance that will automatically be created in the emulator.
+
+              grpcPort:
+                type: number
+                description: |-
+                  The host port to which the Spanner emulator gRPC API is bound.
+                  Override this to run several workspaces in parallel on the same machine. Defaults to `9010`.
+
+              httpPort:
+                type: number
+                description: |-
+                  The host port to which the Spanner emulator HTTP API is bound.
+                  Override this to run several workspaces in parallel on the same machine. Defaults to `9020`.
 
           instance:
             title: GoogleSpannerInstance

--- a/src/emulators/firebase-storage.ts
+++ b/src/emulators/firebase-storage.ts
@@ -29,9 +29,26 @@ export function getFirebaseStorageContainerName(
 }
 
 /**
- * The exposed port for Firebase Storage.
+ * The default exposed host port for Firebase Storage.
  */
 export const FIREBASE_STORAGE_PORT = 9199;
+
+/**
+ * Returns the host port to which the Firebase Storage emulator should be bound.
+ * Reads `google.firebaseStorage.emulator.port`, falling back to {@link FIREBASE_STORAGE_PORT}.
+ *
+ * @param context The {@link WorkspaceContext}.
+ * @returns The host port for the Firebase Storage emulator.
+ */
+export function getFirebaseStorageEmulatorPort(
+  context: WorkspaceContext,
+): number {
+  return (
+    context
+      .asConfiguration<GoogleConfiguration>()
+      .get('google.firebaseStorage.emulator.port') ?? FIREBASE_STORAGE_PORT
+  );
+}
 
 /**
  * The location of the Firebase Storage security rules file within the container.

--- a/src/emulators/firestore.ts
+++ b/src/emulators/firestore.ts
@@ -32,6 +32,21 @@ export function getFirestoreContainerName(context: WorkspaceContext): string {
 export const FIRESTORE_CONTAINER_RULES_FILE = '/firestore.rules';
 
 /**
- * The port on which the Firestore emulator listens.
+ * The default host port on which the Firestore emulator listens.
  */
 export const FIRESTORE_PORT = 8080;
+
+/**
+ * Returns the host port to which the Firestore emulator should be bound.
+ * Reads `google.firestore.emulator.port`, falling back to {@link FIRESTORE_PORT}.
+ *
+ * @param context The {@link WorkspaceContext}.
+ * @returns The host port for the Firestore emulator.
+ */
+export function getFirestoreEmulatorPort(context: WorkspaceContext): number {
+  return (
+    context
+      .asConfiguration<GoogleConfiguration>()
+      .get('google.firestore.emulator.port') ?? FIRESTORE_PORT
+  );
+}

--- a/src/emulators/identity-platform.ts
+++ b/src/emulators/identity-platform.ts
@@ -29,6 +29,23 @@ export function getIdentityPlatformContainerName(
 }
 
 /**
- * The port on which the Firebase Auth emulator is listening.
+ * The default host port on which the Firebase Auth emulator is listening.
  */
 export const FIREBASE_AUTH_PORT = 9099;
+
+/**
+ * Returns the host port to which the Identity Platform (Firebase Auth) emulator should be bound.
+ * Reads `google.identityPlatform.emulator.port`, falling back to {@link FIREBASE_AUTH_PORT}.
+ *
+ * @param context The {@link WorkspaceContext}.
+ * @returns The host port for the Identity Platform emulator.
+ */
+export function getIdentityPlatformEmulatorPort(
+  context: WorkspaceContext,
+): number {
+  return (
+    context
+      .asConfiguration<GoogleConfiguration>()
+      .get('google.identityPlatform.emulator.port') ?? FIREBASE_AUTH_PORT
+  );
+}

--- a/src/emulators/pubsub.ts
+++ b/src/emulators/pubsub.ts
@@ -25,9 +25,24 @@ export function getPubSubContainerName(context: WorkspaceContext): string {
 }
 
 /**
- * The port on which the Pub/Sub emulator is listening.
+ * The default host port on which the Pub/Sub emulator is listening.
  */
 export const PUBSUB_PORT = 8085;
+
+/**
+ * Returns the host port to which the Pub/Sub emulator should be bound.
+ * Reads `google.pubSub.emulator.port`, falling back to {@link PUBSUB_PORT}.
+ *
+ * @param context The {@link WorkspaceContext}.
+ * @returns The host port for the Pub/Sub emulator.
+ */
+export function getPubSubEmulatorPort(context: WorkspaceContext): number {
+  return (
+    context
+      .asConfiguration<GoogleConfiguration>()
+      .get('google.pubSub.emulator.port') ?? PUBSUB_PORT
+  );
+}
 
 /**
  * Formats the name of a Pub/Sub topic as an environment variable.

--- a/src/emulators/spanner.ts
+++ b/src/emulators/spanner.ts
@@ -30,11 +30,41 @@ export function getSpannerContainerName(context: WorkspaceContext): string {
 export const SPANNER_IMAGE = `gcr.io/cloud-spanner-emulator/emulator`;
 
 /**
- * The port on which the Spanner emulator exposes its gRPC API.
+ * The default host port on which the Spanner emulator exposes its gRPC API.
  */
 export const SPANNER_GRPC_PORT = 9010;
 
 /**
- * The port on which the Spanner emulator exposes its HTTP API.
+ * The default host port on which the Spanner emulator exposes its HTTP API.
  */
 export const SPANNER_HTTP_PORT = 9020;
+
+/**
+ * Returns the host port to which the Spanner emulator gRPC API should be bound.
+ * Reads `google.spanner.emulator.grpcPort`, falling back to {@link SPANNER_GRPC_PORT}.
+ *
+ * @param context The {@link WorkspaceContext}.
+ * @returns The host gRPC port for the Spanner emulator.
+ */
+export function getSpannerEmulatorGrpcPort(context: WorkspaceContext): number {
+  return (
+    context
+      .asConfiguration<GoogleConfiguration>()
+      .get('google.spanner.emulator.grpcPort') ?? SPANNER_GRPC_PORT
+  );
+}
+
+/**
+ * Returns the host port to which the Spanner emulator HTTP API should be bound.
+ * Reads `google.spanner.emulator.httpPort`, falling back to {@link SPANNER_HTTP_PORT}.
+ *
+ * @param context The {@link WorkspaceContext}.
+ * @returns The host HTTP port for the Spanner emulator.
+ */
+export function getSpannerEmulatorHttpPort(context: WorkspaceContext): number {
+  return (
+    context
+      .asConfiguration<GoogleConfiguration>()
+      .get('google.spanner.emulator.httpPort') ?? SPANNER_HTTP_PORT
+  );
+}

--- a/src/functions/emulator/start-firebase-storage.spec.ts
+++ b/src/functions/emulator/start-firebase-storage.spec.ts
@@ -88,4 +88,45 @@ describe('EmulatorStartForFirebaseStorage', () => {
       },
     );
   });
+
+  it('should bind the configured host port', async () => {
+    ({ context, functionRegistry } = createContext({
+      configuration: {
+        workspace: { name: 'firebase-storage-test' },
+        google: { firebaseStorage: { emulator: { port: 19199 } } },
+      },
+      functions: [EmulatorStartForFirebaseStorage],
+    }));
+    registerMockFunction(
+      functionRegistry,
+      GoogleFirebaseStorageMergeRules,
+      async () => ({ securityRuleFile: 'security.rules', configuration: {} }),
+    );
+    firebaseEmulatorService = context.service(FirebaseEmulatorService);
+    jest.spyOn(firebaseEmulatorService, 'start').mockResolvedValue();
+
+    const actualResult = await context.call(EmulatorStart, {
+      name: 'google.firebaseStorage',
+    });
+
+    expect(actualResult).toEqual({
+      configuration: {
+        FIREBASE_STORAGE_EMULATOR_HOST: `127.0.0.1:19199`,
+        GOOGLE_CLOUD_PROJECT: 'demo-firebase-storage-test',
+        GCP_PROJECT: 'demo-firebase-storage-test',
+        GCLOUD_PROJECT: 'demo-firebase-storage-test',
+        FIREBASE_STORAGE_BUCKET_NAME: `demo-firebase-storage-test.appspot.com`,
+        FIREBASE_CONFIG: '{}',
+      },
+      name: 'google.firebaseStorage',
+    });
+    expect(firebaseEmulatorService.start).toHaveBeenCalledExactlyOnceWith(
+      'firebase-storage-test-firebase-storage',
+      fileURLToPath(
+        new URL('../../assets/firebase-storage.json', import.meta.url),
+      ),
+      [{ host: '127.0.0.1', container: 9199, local: 19199 }],
+      expect.any(Object),
+    );
+  });
 });

--- a/src/functions/emulator/start-firebase-storage.ts
+++ b/src/functions/emulator/start-firebase-storage.ts
@@ -5,6 +5,7 @@ import {
   FIREBASE_STORAGE_EMULATOR_NAME,
   FIREBASE_STORAGE_PORT,
   getFirebaseStorageContainerName,
+  getFirebaseStorageEmulatorPort,
 } from '../../emulators/index.js';
 import { FirebaseEmulatorService } from '../../services/firebase-emulator.js';
 import { GoogleFirebaseStorageMergeRules } from '../google-firebase-storage/index.js';
@@ -50,6 +51,7 @@ export class EmulatorStartForFirebaseStorage extends EmulatorStart {
     this._context.logger.info('️🍱 Starting Firebase Storage emulator.');
 
     const containerName = getFirebaseStorageContainerName(this._context);
+    const hostPort = getFirebaseStorageEmulatorPort(this._context);
 
     const firebaseEmulatorService = this._context.service(
       FirebaseEmulatorService,
@@ -61,7 +63,7 @@ export class EmulatorStartForFirebaseStorage extends EmulatorStart {
         {
           host: '127.0.0.1',
           container: FIREBASE_STORAGE_PORT,
-          local: FIREBASE_STORAGE_PORT,
+          local: hostPort,
         },
       ],
       {
@@ -83,7 +85,7 @@ export class EmulatorStartForFirebaseStorage extends EmulatorStart {
     );
 
     return {
-      FIREBASE_STORAGE_EMULATOR_HOST: `127.0.0.1:${FIREBASE_STORAGE_PORT}`,
+      FIREBASE_STORAGE_EMULATOR_HOST: `127.0.0.1:${hostPort}`,
       GOOGLE_CLOUD_PROJECT: firebaseEmulatorService.localGcpProject,
       GCP_PROJECT: firebaseEmulatorService.localGcpProject,
       GCLOUD_PROJECT: firebaseEmulatorService.localGcpProject,

--- a/src/functions/emulator/start-firestore.spec.ts
+++ b/src/functions/emulator/start-firestore.spec.ts
@@ -85,4 +85,44 @@ describe('EmulatorStartForFirestore', () => {
       },
     );
   });
+
+  it('should bind the configured host port', async () => {
+    ({ context, functionRegistry } = createContext({
+      configuration: {
+        workspace: { name: 'firestore-test' },
+        google: { firestore: { emulator: { port: 18080 } } },
+      },
+      functions: [EmulatorStartForFirestore],
+    }));
+    registerMockFunction(
+      functionRegistry,
+      GoogleFirestoreMergeRules,
+      async () => ({ securityRuleFile: 'security.rules', configuration: {} }),
+    );
+    gcloudEmulatorService = context.service(GcloudEmulatorService);
+    jest.spyOn(gcloudEmulatorService, 'start').mockResolvedValue();
+
+    const actualResult = await context.call(EmulatorStart, {
+      name: 'google.firestore',
+    });
+
+    expect(actualResult).toEqual({
+      configuration: {
+        FIRESTORE_EMULATOR_HOST: '127.0.0.1:18080',
+        GOOGLE_CLOUD_PROJECT: 'demo-firestore-test',
+        GCP_PROJECT: 'demo-firestore-test',
+        GCLOUD_PROJECT: 'demo-firestore-test',
+        FIREBASE_CONFIG: '{}',
+      },
+      name: 'google.firestore',
+    });
+    expect(gcloudEmulatorService.start).toHaveBeenCalledExactlyOnceWith(
+      'firestore',
+      'firestore-test-firestore',
+      [{ host: '127.0.0.1', local: 18080, container: 8080 }],
+      expect.objectContaining({
+        availabilityEndpoint: 'http://127.0.0.1:18080/',
+      }),
+    );
+  });
 });

--- a/src/functions/emulator/start-firestore.ts
+++ b/src/functions/emulator/start-firestore.ts
@@ -4,6 +4,7 @@ import {
   FIRESTORE_EMULATOR_NAME,
   FIRESTORE_PORT,
   getFirestoreContainerName,
+  getFirestoreEmulatorPort,
 } from '../../emulators/index.js';
 import { GcloudEmulatorService } from '../../services/gcloud-emulator.js';
 import { GoogleFirestoreMergeRules } from '../google-firestore/index.js';
@@ -41,18 +42,13 @@ export class EmulatorStartForFirestore extends EmulatorStart {
     this._context.logger.info('🗃️ Starting Firestore emulator.');
 
     const containerName = getFirestoreContainerName(this._context);
+    const hostPort = getFirestoreEmulatorPort(this._context);
 
     const gcloudEmulatorService = this._context.service(GcloudEmulatorService);
     await gcloudEmulatorService.start(
       'firestore',
       containerName,
-      [
-        {
-          host: '127.0.0.1',
-          local: FIRESTORE_PORT,
-          container: FIRESTORE_PORT,
-        },
-      ],
+      [{ host: '127.0.0.1', local: hostPort, container: FIRESTORE_PORT }],
       {
         mounts: [
           {
@@ -63,7 +59,7 @@ export class EmulatorStartForFirestore extends EmulatorStart {
           },
         ],
         additionalArguments: ['--rules', FIRESTORE_CONTAINER_RULES_FILE],
-        availabilityEndpoint: `http://127.0.0.1:${FIRESTORE_PORT}/`,
+        availabilityEndpoint: `http://127.0.0.1:${hostPort}/`,
       },
     );
 
@@ -72,7 +68,7 @@ export class EmulatorStartForFirestore extends EmulatorStart {
     );
 
     return {
-      FIRESTORE_EMULATOR_HOST: `127.0.0.1:${FIRESTORE_PORT}`,
+      FIRESTORE_EMULATOR_HOST: `127.0.0.1:${hostPort}`,
       GOOGLE_CLOUD_PROJECT: gcloudEmulatorService.localGcpProject,
       GCP_PROJECT: gcloudEmulatorService.localGcpProject,
       GCLOUD_PROJECT: gcloudEmulatorService.localGcpProject,

--- a/src/functions/emulator/start-identity-platform.spec.ts
+++ b/src/functions/emulator/start-identity-platform.spec.ts
@@ -63,4 +63,38 @@ describe('EmulatorStartForIdentityPlatform', () => {
       [{ host: '127.0.0.1', container: 9099, local: 9099 }],
     );
   });
+
+  it('should bind the configured host port', async () => {
+    ({ context } = createContext({
+      configuration: {
+        workspace: { name: 'identity-platform-test' },
+        google: { identityPlatform: { emulator: { port: 19099 } } },
+      },
+      functions: [EmulatorStartForIdentityPlatform],
+    }));
+    firebaseEmulatorService = context.service(FirebaseEmulatorService);
+    jest.spyOn(firebaseEmulatorService, 'start').mockResolvedValue();
+
+    const actualResult = await context.call(EmulatorStart, {
+      name: 'google.identityPlatform',
+    });
+
+    expect(actualResult).toEqual({
+      configuration: {
+        FIREBASE_AUTH_EMULATOR_HOST: `127.0.0.1:19099`,
+        GOOGLE_CLOUD_PROJECT: 'demo-identity-platform-test',
+        GCP_PROJECT: 'demo-identity-platform-test',
+        GCLOUD_PROJECT: 'demo-identity-platform-test',
+        FIREBASE_CONFIG: '{}',
+      },
+      name: 'google.identityPlatform',
+    });
+    expect(firebaseEmulatorService.start).toHaveBeenCalledExactlyOnceWith(
+      'identity-platform-test-identity-platform',
+      fileURLToPath(
+        new URL('../../assets/firebase-auth.json', import.meta.url),
+      ),
+      [{ host: '127.0.0.1', container: 9099, local: 19099 }],
+    );
+  });
 });

--- a/src/functions/emulator/start-identity-platform.ts
+++ b/src/functions/emulator/start-identity-platform.ts
@@ -4,6 +4,7 @@ import {
   FIREBASE_AUTH_PORT,
   IDENTITY_PLATFORM_EMULATOR_NAME,
   getIdentityPlatformContainerName,
+  getIdentityPlatformEmulatorPort,
 } from '../../emulators/index.js';
 import { FirebaseEmulatorService } from '../../services/firebase-emulator.js';
 
@@ -42,16 +43,13 @@ export class EmulatorStartForIdentityPlatform extends EmulatorStart {
     this._context.logger.info('🛂 Starting the Identity Platform emulator.');
 
     const containerName = getIdentityPlatformContainerName(this._context);
+    const hostPort = getIdentityPlatformEmulatorPort(this._context);
 
     const firebaseEmulatorService = this._context.service(
       FirebaseEmulatorService,
     );
     await firebaseEmulatorService.start(containerName, FIREBASE_CONF_FILE, [
-      {
-        host: '127.0.0.1',
-        local: FIREBASE_AUTH_PORT,
-        container: FIREBASE_AUTH_PORT,
-      },
+      { host: '127.0.0.1', local: hostPort, container: FIREBASE_AUTH_PORT },
     ]);
 
     this._context.logger.info(
@@ -59,7 +57,7 @@ export class EmulatorStartForIdentityPlatform extends EmulatorStart {
     );
 
     return {
-      FIREBASE_AUTH_EMULATOR_HOST: `127.0.0.1:${FIREBASE_AUTH_PORT}`,
+      FIREBASE_AUTH_EMULATOR_HOST: `127.0.0.1:${hostPort}`,
       GOOGLE_CLOUD_PROJECT: firebaseEmulatorService.localGcpProject,
       GCP_PROJECT: firebaseEmulatorService.localGcpProject,
       GCLOUD_PROJECT: firebaseEmulatorService.localGcpProject,

--- a/src/functions/emulator/start-pubsub.call.ts
+++ b/src/functions/emulator/start-pubsub.call.ts
@@ -10,6 +10,7 @@ import {
   PUBSUB_PORT,
   formatPubSubTopicAsEnvironmentVariable,
   getPubSubContainerName,
+  getPubSubEmulatorPort,
 } from '../../emulators/index.js';
 import { GcloudEmulatorService } from '../../services/gcloud-emulator.js';
 import type { EmulatorStartForPubSub } from './start-pubsub.js';
@@ -30,8 +31,9 @@ async function startPubSub(
     return {};
   }
 
-  const emulatorConf = await startPubSubEmulator(context);
-  const topicsConf = await createTopicsIfNeeded(context);
+  const hostPort = getPubSubEmulatorPort(context);
+  const emulatorConf = await startPubSubEmulator(context, hostPort);
+  const topicsConf = await createTopicsIfNeeded(context, hostPort);
 
   context.logger.info('📫 Successfully initialized Pub/Sub emulator.');
 
@@ -40,6 +42,7 @@ async function startPubSub(
 
 async function startPubSubEmulator(
   context: WorkspaceContext,
+  hostPort: number,
 ): Promise<Record<string, string>> {
   context.logger.info('📫 Starting Pub/Sub emulator.');
 
@@ -50,14 +53,14 @@ async function startPubSubEmulator(
   await gcloudEmulatorService.start(
     'pubsub',
     containerName,
-    [{ host: '127.0.0.1', local: PUBSUB_PORT, container: PUBSUB_PORT }],
+    [{ host: '127.0.0.1', local: hostPort, container: PUBSUB_PORT }],
     {
-      availabilityEndpoint: `http://127.0.0.1:${PUBSUB_PORT}/v1/projects/${gcpProject}/topics`,
+      availabilityEndpoint: `http://127.0.0.1:${hostPort}/v1/projects/${gcpProject}/topics`,
     },
   );
 
   return {
-    PUBSUB_EMULATOR_HOST: `127.0.0.1:${PUBSUB_PORT}`,
+    PUBSUB_EMULATOR_HOST: `127.0.0.1:${hostPort}`,
     GOOGLE_CLOUD_PROJECT: gcloudEmulatorService.localGcpProject,
     GCP_PROJECT: gcloudEmulatorService.localGcpProject,
     GCLOUD_PROJECT: gcloudEmulatorService.localGcpProject,
@@ -66,6 +69,7 @@ async function startPubSubEmulator(
 
 async function createTopicsIfNeeded(
   context: WorkspaceContext,
+  hostPort: number,
 ): Promise<Record<string, string>> {
   if (context.get('events.broker') !== 'google.pubSub') {
     context.logger.warn(
@@ -80,7 +84,7 @@ async function createTopicsIfNeeded(
 
   const pubSub = new PubSub({
     projectId: gcpProject,
-    apiEndpoint: `127.0.0.1:${PUBSUB_PORT}`,
+    apiEndpoint: `127.0.0.1:${hostPort}`,
   });
 
   const envVars = await Promise.all(

--- a/src/functions/emulator/start-pubsub.spec.ts
+++ b/src/functions/emulator/start-pubsub.spec.ts
@@ -13,10 +13,11 @@ import { createContext, registerMockFunction } from '@causa/workspace/testing';
 import { PubSub } from '@google-cloud/pubsub';
 import { jest } from '@jest/globals';
 import 'jest-extended';
-import { PUBSUB_PORT } from '../../emulators/index.js';
 import { GcloudEmulatorService } from '../../services/gcloud-emulator.js';
 import { EmulatorStartForPubSub } from './start-pubsub.js';
 import { EmulatorStopForPubSub } from './stop-pubsub.js';
+
+const PUBSUB_HOST_PORT = 18085;
 
 describe('EmulatorStartForPubSub', () => {
   let context: WorkspaceContext;
@@ -28,6 +29,7 @@ describe('EmulatorStartForPubSub', () => {
       configuration: {
         workspace: { name: 'pubsub-test' },
         events: { broker: 'google.pubSub' },
+        google: { pubSub: { emulator: { port: PUBSUB_HOST_PORT } } },
       },
       functions: [EmulatorStartForPubSub, EmulatorStopForPubSub],
     }));
@@ -89,7 +91,7 @@ describe('EmulatorStartForPubSub', () => {
 
     expect(actualResult.name).toEqual('google.pubSub');
     expect(actualResult.configuration).toEqual({
-      PUBSUB_EMULATOR_HOST: '127.0.0.1:8085',
+      PUBSUB_EMULATOR_HOST: `127.0.0.1:${PUBSUB_HOST_PORT}`,
       GOOGLE_CLOUD_PROJECT: 'demo-pubsub-test',
       GCP_PROJECT: 'demo-pubsub-test',
       GCLOUD_PROJECT: 'demo-pubsub-test',
@@ -109,6 +111,7 @@ describe('EmulatorStartForPubSub', () => {
       configuration: {
         workspace: { name: 'pubsub-test' },
         events: { broker: '📫' },
+        google: { pubSub: { emulator: { port: PUBSUB_HOST_PORT } } },
       },
       functions: [EmulatorStartForPubSub, EmulatorStopForPubSub],
     }));
@@ -124,7 +127,7 @@ describe('EmulatorStartForPubSub', () => {
 
     expect(actualResult.name).toEqual('google.pubSub');
     expect(actualResult.configuration).toEqual({
-      PUBSUB_EMULATOR_HOST: '127.0.0.1:8085',
+      PUBSUB_EMULATOR_HOST: `127.0.0.1:${PUBSUB_HOST_PORT}`,
       GOOGLE_CLOUD_PROJECT: 'demo-pubsub-test',
       GCP_PROJECT: 'demo-pubsub-test',
       GCLOUD_PROJECT: 'demo-pubsub-test',
@@ -135,7 +138,7 @@ describe('EmulatorStartForPubSub', () => {
   async function getPubSubEmulatorTopics(): Promise<string[]> {
     const [topics] = await new PubSub({
       projectId: 'demo-pubsub-test',
-      apiEndpoint: `127.0.0.1:${PUBSUB_PORT}`,
+      apiEndpoint: `127.0.0.1:${PUBSUB_HOST_PORT}`,
     }).getTopics();
     return topics.map((t) => t.name).sort();
   }

--- a/src/functions/emulator/start-spanner.call.ts
+++ b/src/functions/emulator/start-spanner.call.ts
@@ -16,6 +16,8 @@ import {
   SPANNER_HTTP_PORT,
   SPANNER_IMAGE,
   getSpannerContainerName,
+  getSpannerEmulatorGrpcPort,
+  getSpannerEmulatorHttpPort,
 } from '../../emulators/index.js';
 import { GoogleSpannerListDatabases } from '../google-spanner/index.js';
 import type { EmulatorStartForSpanner } from './start-spanner.js';
@@ -36,8 +38,17 @@ async function startSpanner(
     return {};
   }
 
-  const emulatorConf = await startSpannerEmulator(context);
-  const instanceAndDatabaseConf = await initializeEmulator(context);
+  const grpcHostPort = getSpannerEmulatorGrpcPort(context);
+  const httpHostPort = getSpannerEmulatorHttpPort(context);
+  const emulatorConf = await startSpannerEmulator(
+    context,
+    grpcHostPort,
+    httpHostPort,
+  );
+  const instanceAndDatabaseConf = await initializeEmulator(
+    context,
+    grpcHostPort,
+  );
 
   context.logger.info('🗃️ Successfully initialized Spanner emulator.');
 
@@ -46,6 +57,8 @@ async function startSpanner(
 
 async function startSpannerEmulator(
   context: WorkspaceContext,
+  grpcHostPort: number,
+  httpHostPort: number,
 ): Promise<Record<string, string>> {
   context.logger.info('🗃️ Starting Spanner emulator.');
 
@@ -60,20 +73,19 @@ async function startSpannerEmulator(
   await dockerEmulatorService.start(
     `${SPANNER_IMAGE}:${imageVersion}`,
     containerName,
-    [SPANNER_GRPC_PORT, SPANNER_HTTP_PORT].map((p) => ({
-      host: '127.0.0.1',
-      local: p,
-      container: p,
-    })) as any,
+    [
+      { host: '127.0.0.1', local: grpcHostPort, container: SPANNER_GRPC_PORT },
+      { host: '127.0.0.1', local: httpHostPort, container: SPANNER_HTTP_PORT },
+    ],
   );
 
   await dockerEmulatorService.waitForAvailability(
     containerName,
-    `http://127.0.0.1:${SPANNER_HTTP_PORT}/v1/projects/${gcpProject}/instances`,
+    `http://127.0.0.1:${httpHostPort}/v1/projects/${gcpProject}/instances`,
   );
 
   return {
-    SPANNER_EMULATOR_HOST: `127.0.0.1:${SPANNER_GRPC_PORT}`,
+    SPANNER_EMULATOR_HOST: `127.0.0.1:${grpcHostPort}`,
     GOOGLE_CLOUD_PROJECT: gcpProject,
     GCP_PROJECT: gcpProject,
     GCLOUD_PROJECT: gcpProject,
@@ -82,10 +94,11 @@ async function startSpannerEmulator(
 
 async function initializeEmulator(
   context: WorkspaceContext,
+  port: number,
 ): Promise<Record<string, string>> {
   const spanner = new Spanner({
     servicePath: '127.0.0.1',
-    port: SPANNER_GRPC_PORT,
+    port,
     projectId: getLocalGcpProject(context),
     sslCreds: grpc.credentials.createInsecure(),
   });

--- a/src/functions/emulator/start-spanner.spec.ts
+++ b/src/functions/emulator/start-spanner.spec.ts
@@ -21,6 +21,9 @@ import { GoogleSpannerListDatabases } from '../google-spanner/index.js';
 import { EmulatorStartForSpanner } from './start-spanner.js';
 import { EmulatorStopForSpanner } from './stop-spanner.js';
 
+const SPANNER_HOST_GRPC_PORT = 19010;
+const SPANNER_HOST_HTTP_PORT = 19020;
+
 describe('EmulatorStartForSpanner', () => {
   let context: WorkspaceContext;
   let functionRegistry: FunctionRegistry<WorkspaceContext>;
@@ -29,7 +32,17 @@ describe('EmulatorStartForSpanner', () => {
 
   beforeEach(async () => {
     ({ context, functionRegistry } = createContext({
-      configuration: { workspace: { name: 'spanner-test' } },
+      configuration: {
+        workspace: { name: 'spanner-test' },
+        google: {
+          spanner: {
+            emulator: {
+              grpcPort: SPANNER_HOST_GRPC_PORT,
+              httpPort: SPANNER_HOST_HTTP_PORT,
+            },
+          },
+        },
+      },
       functions: [EmulatorStartForSpanner, EmulatorStopForSpanner],
     }));
 
@@ -83,7 +96,7 @@ describe('EmulatorStartForSpanner', () => {
 
     expect(actualResult.name).toEqual('google.spanner');
     expect(actualResult.configuration).toEqual({
-      SPANNER_EMULATOR_HOST: `127.0.0.1:9010`,
+      SPANNER_EMULATOR_HOST: `127.0.0.1:${SPANNER_HOST_GRPC_PORT}`,
       GOOGLE_CLOUD_PROJECT: 'demo-spanner-test',
       GCP_PROJECT: 'demo-spanner-test',
       GCLOUD_PROJECT: 'demo-spanner-test',
@@ -115,7 +128,7 @@ describe('EmulatorStartForSpanner', () => {
 
     expect(actualResult.name).toEqual('google.spanner');
     expect(actualResult.configuration).toEqual({
-      SPANNER_EMULATOR_HOST: `127.0.0.1:9010`,
+      SPANNER_EMULATOR_HOST: `127.0.0.1:${SPANNER_HOST_GRPC_PORT}`,
       GOOGLE_CLOUD_PROJECT: 'demo-spanner-test',
       GCP_PROJECT: 'demo-spanner-test',
       GCLOUD_PROJECT: 'demo-spanner-test',
@@ -140,7 +153,7 @@ describe('EmulatorStartForSpanner', () => {
   async function getSpannerDatabases(): Promise<Record<string, string[]>> {
     const spanner = new Spanner({
       servicePath: '127.0.0.1',
-      port: 9010,
+      port: SPANNER_HOST_GRPC_PORT,
       projectId: 'demo-spanner-test',
       sslCreds: grpc.credentials.createInsecure(),
     });

--- a/src/functions/google-firestore/query-records.spec.ts
+++ b/src/functions/google-firestore/query-records.spec.ts
@@ -1,53 +1,88 @@
 import { WorkspaceContext } from '@causa/workspace';
-import { DatabaseQueryRecords } from '@causa/workspace-core';
-import { DockerEmulatorService } from '@causa/workspace-core/services';
-import { NoImplementationFoundError } from '@causa/workspace/function-registry';
-import { createContext } from '@causa/workspace/testing';
+import {
+  DatabaseQueryRecords,
+  EmulatorStart,
+  EmulatorStop,
+} from '@causa/workspace-core';
+import {
+  FunctionRegistry,
+  NoImplementationFoundError,
+} from '@causa/workspace/function-registry';
+import { createContext, registerMockFunction } from '@causa/workspace/testing';
 import { deleteApp, initializeApp } from 'firebase-admin/app';
 import { GeoPoint, Timestamp, getFirestore } from 'firebase-admin/firestore';
 import 'jest-extended';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
 import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import {
+  EmulatorStartForFirestore,
+  EmulatorStopForFirestore,
+} from '../emulator/index.js';
+import { GoogleFirestoreMergeRules } from './merge-rules.js';
 import { DatabaseQueryRecordsForFirestore } from './query-records.js';
 
-const FIRESTORE_IMAGE =
-  'gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators';
-const FIRESTORE_HOST_PORT = 18080;
+const FIRESTORE_HOST_PORT = 28080;
 const FIRESTORE_CONTAINER_NAME = 'causa-test-firestore-query-records';
 const PROJECT_ID = 'demo-firestore-query-records';
 const COLLECTION = 'singers';
 
 describe('DatabaseQueryRecordsForFirestore', () => {
   let context: WorkspaceContext;
-  let dockerEmulatorService: DockerEmulatorService;
+  let functionRegistry: FunctionRegistry<WorkspaceContext>;
+  let rulesDir: string;
+  let initialEnv: Record<string, string | undefined>;
 
   beforeAll(async () => {
-    ({ context } = createContext({
+    initialEnv = process.env;
+
+    rulesDir = resolve(await mkdtemp(join(tmpdir(), 'causa-firestore-rules-')));
+    const rulesFile = join(rulesDir, 'firestore.rules');
+    await writeFile(
+      rulesFile,
+      `rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if true;
+    }
+  }
+}
+`,
+    );
+
+    ({ context, functionRegistry } = createContext({
       configuration: {
         workspace: { name: 'firestore-query-records-test' },
-        google: { project: PROJECT_ID },
+        google: {
+          project: PROJECT_ID,
+          localProject: PROJECT_ID,
+          firestore: {
+            emulator: {
+              containerName: FIRESTORE_CONTAINER_NAME,
+              port: FIRESTORE_HOST_PORT,
+            },
+          },
+        },
       },
-      functions: [DatabaseQueryRecordsForFirestore],
+      functions: [
+        EmulatorStartForFirestore,
+        EmulatorStopForFirestore,
+        DatabaseQueryRecordsForFirestore,
+      ],
     }));
-    dockerEmulatorService = context.service(DockerEmulatorService);
-    await dockerEmulatorService.start(
-      FIRESTORE_IMAGE,
-      FIRESTORE_CONTAINER_NAME,
-      [{ host: '127.0.0.1', local: FIRESTORE_HOST_PORT, container: 8080 }],
-      {
-        commandAndArgs: [
-          'gcloud',
-          'emulators',
-          'firestore',
-          'start',
-          '--host-port=0.0.0.0:8080',
-        ],
-      },
+    registerMockFunction(
+      functionRegistry,
+      GoogleFirestoreMergeRules,
+      async () => ({ securityRuleFile: rulesFile, configuration: {} }),
     );
-    await dockerEmulatorService.waitForAvailability(
-      FIRESTORE_CONTAINER_NAME,
-      `http://127.0.0.1:${FIRESTORE_HOST_PORT}/`,
-    );
-    process.env.FIRESTORE_EMULATOR_HOST = `127.0.0.1:${FIRESTORE_HOST_PORT}`;
+
+    const { configuration } = await context.call(EmulatorStart, {
+      name: 'google.firestore',
+    });
+    process.env = { ...initialEnv, ...configuration };
+
     const app = initializeApp({ projectId: PROJECT_ID }, randomUUID());
     try {
       const firestore = getFirestore(app);
@@ -70,8 +105,9 @@ describe('DatabaseQueryRecordsForFirestore', () => {
   }, 300000);
 
   afterAll(async () => {
-    delete process.env.FIRESTORE_EMULATOR_HOST;
-    await dockerEmulatorService.stop(FIRESTORE_CONTAINER_NAME);
+    await context.call(EmulatorStop, { name: 'google.firestore' });
+    await rm(rulesDir, { recursive: true, force: true });
+    process.env = initialEnv;
   });
 
   it('should not support a different engine', () => {

--- a/src/functions/google-spanner/query-records.spec.ts
+++ b/src/functions/google-spanner/query-records.spec.ts
@@ -1,19 +1,29 @@
 import { WorkspaceContext } from '@causa/workspace';
-import { DatabaseQueryRecords } from '@causa/workspace-core';
-import { DockerEmulatorService } from '@causa/workspace-core/services';
-import { NoImplementationFoundError } from '@causa/workspace/function-registry';
-import { createContext } from '@causa/workspace/testing';
+import {
+  DatabaseQueryRecords,
+  EmulatorStart,
+  EmulatorStop,
+} from '@causa/workspace-core';
+import {
+  FunctionRegistry,
+  NoImplementationFoundError,
+} from '@causa/workspace/function-registry';
+import { createContext, registerMockFunction } from '@causa/workspace/testing';
 import { Spanner } from '@google-cloud/spanner';
 import { grpc } from 'google-gax';
 import 'jest-extended';
+import {
+  EmulatorStartForSpanner,
+  EmulatorStopForSpanner,
+} from '../emulator/index.js';
+import { GoogleSpannerListDatabases } from './list-databases.js';
 import {
   DatabaseQueryRecordsForSpanner,
   SPANNER_QUERY_RECORDS_LIMIT,
 } from './query-records.js';
 
-const SPANNER_IMAGE = 'gcr.io/cloud-spanner-emulator/emulator:latest';
-const SPANNER_HOST_GRPC_PORT = 19010;
-const SPANNER_HOST_HTTP_PORT = 19020;
+const SPANNER_HOST_GRPC_PORT = 29010;
+const SPANNER_HOST_HTTP_PORT = 29020;
 const SPANNER_CONTAINER_NAME = 'causa-test-spanner-query-records';
 const PROJECT_ID = 'demo-spanner-query-records';
 const INSTANCE_NAME = 'local';
@@ -21,50 +31,61 @@ const DATABASE_NAME = 'my-db';
 
 describe('DatabaseQueryRecordsForSpanner', () => {
   let context: WorkspaceContext;
-  let dockerEmulatorService: DockerEmulatorService;
+  let functionRegistry: FunctionRegistry<WorkspaceContext>;
+  let initialEnv: Record<string, string | undefined>;
 
   beforeAll(async () => {
-    ({ context } = createContext({
+    initialEnv = process.env;
+
+    ({ context, functionRegistry } = createContext({
       configuration: {
         workspace: { name: 'spanner-query-records-test' },
         google: {
           project: PROJECT_ID,
-          spanner: { instance: { name: INSTANCE_NAME } },
+          localProject: PROJECT_ID,
+          spanner: {
+            instance: { name: INSTANCE_NAME },
+            emulator: {
+              containerName: SPANNER_CONTAINER_NAME,
+              instanceName: INSTANCE_NAME,
+              grpcPort: SPANNER_HOST_GRPC_PORT,
+              httpPort: SPANNER_HOST_HTTP_PORT,
+            },
+          },
         },
       },
-      functions: [DatabaseQueryRecordsForSpanner],
+      functions: [
+        EmulatorStartForSpanner,
+        EmulatorStopForSpanner,
+        DatabaseQueryRecordsForSpanner,
+      ],
     }));
-    dockerEmulatorService = context.service(DockerEmulatorService);
-    await dockerEmulatorService.start(SPANNER_IMAGE, SPANNER_CONTAINER_NAME, [
-      { host: '127.0.0.1', local: SPANNER_HOST_GRPC_PORT, container: 9010 },
-      { host: '127.0.0.1', local: SPANNER_HOST_HTTP_PORT, container: 9020 },
-    ]);
-    await dockerEmulatorService.waitForAvailability(
-      SPANNER_CONTAINER_NAME,
-      `http://127.0.0.1:${SPANNER_HOST_HTTP_PORT}/v1/projects/${PROJECT_ID}/instances`,
+    registerMockFunction(
+      functionRegistry,
+      GoogleSpannerListDatabases,
+      async () => [
+        {
+          id: DATABASE_NAME,
+          ddlFiles: [],
+          ddls: [
+            'CREATE TABLE Singers (id INT64 NOT NULL, name STRING(MAX)) PRIMARY KEY (id)',
+          ],
+        },
+      ],
     );
-    process.env.SPANNER_EMULATOR_HOST = `127.0.0.1:${SPANNER_HOST_GRPC_PORT}`;
+
+    const { configuration } = await context.call(EmulatorStart, {
+      name: 'google.spanner',
+    });
+    process.env = { ...initialEnv, ...configuration };
+
     const spanner = new Spanner({
       servicePath: '127.0.0.1',
       port: SPANNER_HOST_GRPC_PORT,
       projectId: PROJECT_ID,
       sslCreds: grpc.credentials.createInsecure(),
     });
-    const [instance, instanceOp] = await spanner.createInstance(INSTANCE_NAME, {
-      config: 'emulator-config',
-      displayName: INSTANCE_NAME,
-      processingUnits: 100,
-    });
-    await instanceOp.promise();
-    const [database, databaseOp] = await instance.createDatabase(
-      DATABASE_NAME,
-      {
-        schema: [
-          'CREATE TABLE Singers (id INT64 NOT NULL, name STRING(MAX)) PRIMARY KEY (id)',
-        ],
-      },
-    );
-    await databaseOp.promise();
+    const database = spanner.instance(INSTANCE_NAME).database(DATABASE_NAME);
     await database.table('Singers').insert([
       { id: 1, name: 'Eddie' },
       { id: 2, name: 'Wilson' },
@@ -74,8 +95,8 @@ describe('DatabaseQueryRecordsForSpanner', () => {
   }, 300000);
 
   afterAll(async () => {
-    delete process.env.SPANNER_EMULATOR_HOST;
-    await dockerEmulatorService.stop(SPANNER_CONTAINER_NAME);
+    await context.call(EmulatorStop, { name: 'google.spanner' });
+    process.env = initialEnv;
   });
 
   it('should not support a different engine', () => {

--- a/src/functions/project/push-artefact-cloud-functions.spec.ts
+++ b/src/functions/project/push-artefact-cloud-functions.spec.ts
@@ -33,6 +33,7 @@ describe('ProjectPushArtefactForCloudFunctions', () => {
       rootPath: emulatorTmpDir,
       configuration: {
         workspace: { name: 'emulator-cf' },
+        google: { firebaseStorage: { emulator: { port: 19199 } } },
       },
       functions: [
         GoogleFirebaseStorageMergeRules,


### PR DESCRIPTION
### 📝 Description of the PR

Adds optional configuration keys to override the host port each emulator binds to, so multiple workspaces can run their emulators in parallel on the same machine without port clashes. The new keys are siblings of the existing `containerName` overrides:

- `google.firestore.emulator.port`
- `google.pubSub.emulator.port`
- `google.firebaseStorage.emulator.port`
- `google.identityPlatform.emulator.port`
- `google.spanner.emulator.grpcPort`
- `google.spanner.emulator.httpPort`

When unset, each emulator keeps its previous default port, so existing workspaces are unaffected. Returned environment variables (`FIRESTORE_EMULATOR_HOST`, `PUBSUB_EMULATOR_HOST`, etc.) are derived from the configured port so downstream consumers pick up the override automatically.

Existing Docker-backed tests were also migrated to non-default, mutually-distinct ports, and the `DatabaseQueryRecords` integration tests now rely on the `EmulatorStart` / `EmulatorStop` workspace functions instead of starting their own Docker containers.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.