### PR TITLE
🔖 Prepare v0.18.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.18.0-beta.3 (2026-05-27)
+
 Features:
 
 - Implement `EventTopicBrokerWaitForProcessing` for Pub/Sub, polling Cloud Monitoring metrics until all temporary subscriptions of the targeted backfill are drained.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.18.0-beta.2",
+  "version": "0.18.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-google",
-      "version": "0.18.0-beta.2",
+      "version": "0.18.0-beta.3",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.8.0-beta.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.18.0-beta.2",
+  "version": "0.18.0-beta.3",
   "description": "The Causa workspace module providing many functionalities related to GCP and its services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Features:

- Implement `EventTopicBrokerWaitForProcessing` for Pub/Sub, polling Cloud Monitoring metrics until all temporary subscriptions of the targeted backfill are drained.
- Add the `google.firestore.emulator.port`, `google.pubSub.emulator.port`, `google.firebaseStorage.emulator.port`, `google.identityPlatform.emulator.port`, `google.spanner.emulator.grpcPort`, and `google.spanner.emulator.httpPort` configurations to override the host ports bound by the emulators, enabling several workspaces to run their emulators in parallel on the same machine.