### PR TITLE
🔖 Prepare v0.18.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.18.0-beta.4 (2026-06-08)
+
 Features:
 
 - Add the `google.pubSub.backfillPublishOptions` configuration to override the Pub/Sub publish options used when backfilling events.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.18.0-beta.3",
+  "version": "0.18.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-google",
-      "version": "0.18.0-beta.3",
+      "version": "0.18.0-beta.4",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.8.0-beta.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-google",
-  "version": "0.18.0-beta.3",
+  "version": "0.18.0-beta.4",
   "description": "The Causa workspace module providing many functionalities related to GCP and its services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Features:

- Add the `google.pubSub.backfillPublishOptions` configuration to override the Pub/Sub publish options used when backfilling events.
- Add the `google.cloudRun.eventBackfillServiceCloneConfig` configuration. When set, project-scoped backfill triggers deploy a temporary internal-ingress copy of the Cloud Run service (one per trigger) instead of sending events to the live service, isolating the backfill load and scaling from production. The `minInstanceCount`, `maxInstanceCount`, and `requestConcurrency` properties override the scaling of the copy, which is deleted during backfill cleanup.