### PR TITLE
🐛 Use aliased imports for generated Spanner and Firestore decorators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Generate aliased imports for the Google Spanner and Firestore decorators (`@SpannerTable`, `@SpannerColumn`, `@FirestoreCollection`, `@SoftDeletedFirestoreCollection`), preventing the external decorator imports from clashing with generated type names.
+
 ## v1.0.0 (2026-06-09)
 
 This release includes all the changes from the `v0.18.0-beta.*` version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "@causa/cli": "^1.0.0",
-        "@causa/workspace": "^1.0.0",
+        "@causa/workspace": "^1.0.1",
         "@causa/workspace-core": "^1.0.1",
-        "@causa/workspace-typescript": "^1.0.0",
+        "@causa/workspace-typescript": "^1.0.1",
         "@google-cloud/apikeys": "^2.2.2",
         "@google-cloud/bigquery": "^8.3.1",
         "@google-cloud/iam-credentials": "^4.2.2",
@@ -35,7 +35,7 @@
         "pino": "^10.3.1"
       },
       "devDependencies": {
-        "@swc/core": "^1.15.40",
+        "@swc/core": "^1.15.41",
         "@swc/jest": "^0.2.39",
         "@tsconfig/node22": "^22.0.5",
         "@types/jest": "^30.0.0",
@@ -623,9 +623,9 @@
       }
     },
     "node_modules/@causa/workspace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@causa/workspace/-/workspace-1.0.0.tgz",
-      "integrity": "sha512-GELvGct2UF9wB0neXLmNOUD78EqdbfIIFK4KiQRT3h73VOmAdNedT3q+YjdOwcstp9gR5xIDCwS27JLprXXIWQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@causa/workspace/-/workspace-1.0.1.tgz",
+      "integrity": "sha512-bjPqsykPrcwruCUAKR5EIzth8THimEGgvsHxHeMGGqWfjRoH7GealWrL8efRFK4LC7K25FXm2kxUJltUs5Iptg==",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.17.24",
@@ -666,9 +666,9 @@
       }
     },
     "node_modules/@causa/workspace-typescript": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@causa/workspace-typescript/-/workspace-typescript-1.0.0.tgz",
-      "integrity": "sha512-u9rAIV6LdEOrpyiqbMtetrUOaq/qk9qyy/6sJjzKi06txS7jmgnLBxXEOBst4Z6NnZPYyKfovYmkj6dIBKIfdA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@causa/workspace-typescript/-/workspace-typescript-1.0.1.tgz",
+      "integrity": "sha512-9pC5V3XerqMTJypoZhdPYewDTiVdQa3lDXygBUnzOyzraop5NYQOmfFPcej+Q8AN7nzls5e9OSycZn8kW0MAxw==",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": "^1.0.0",
@@ -3020,14 +3020,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -3273,21 +3273,21 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@scalar/helpers": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.8.1.tgz",
-      "integrity": "sha512-yuiuBCadP5bjAnIv23QvifVN/NaMi9xBF6b8Wdk4QOzwzLPJmp699MAdf33J0A5i2qKcvnu32iz/VkEJmQRe5g==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.8.2.tgz",
+      "integrity": "sha512-qNbqUjSB3S4Gr4A0oANcm5G1Ip+EqBxICYKhe9YzmnaBpbmW6shxqpiivApTvvuDf+uIhR3uMwWyVQbYcGLsxA==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/json-magic": {
-      "version": "0.12.15",
-      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.12.15.tgz",
-      "integrity": "sha512-ZYgdYZ0jSZXQeyhG2lJ20FjzvKsaDRXk4bPguF/Ytl2nGBh9a6RIIr9NvVy4zAD67a/ahm+xipXlfoR1KtB5fg==",
+      "version": "0.12.16",
+      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.12.16.tgz",
+      "integrity": "sha512-w8cDbZhHCzmIblWx92IVWoAXsbI4Fz3m++jiBANTSO1hgphF6UqEPQiCt3wnMPaxaanjMQxjS/iBk1UGXR2EGA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.8.1",
+        "@scalar/helpers": "0.8.2",
         "pathe": "^2.0.3",
         "yaml": "^2.8.3"
       },
@@ -3296,13 +3296,13 @@
       }
     },
     "node_modules/@scalar/openapi-parser": {
-      "version": "0.28.6",
-      "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.28.6.tgz",
-      "integrity": "sha512-gCl4r+rpmO+CKfwmmwI+GJVFhuNut7e6beUcD/xazanH4epkLT7V9ZgMv9YKbUBE73fkrOv6NJympeEGiU8aUw==",
+      "version": "0.28.7",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.28.7.tgz",
+      "integrity": "sha512-E6beEdTsJxUStxOmY1knQvSNJq6LTiXOsRX2WTrfmU6d/kiATn6IKkAU0kXtAZkaYCGU4UCEmBFHCMmNKn0JLA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.8.1",
-        "@scalar/json-magic": "0.12.15",
+        "@scalar/helpers": "0.8.2",
+        "@scalar/json-magic": "0.12.16",
         "@scalar/openapi-types": "0.9.1",
         "@scalar/openapi-upgrader": "0.2.9",
         "ajv": "^8.17.1",
@@ -3376,9 +3376,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.40.tgz",
-      "integrity": "sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.41.tgz",
+      "integrity": "sha512-03nQq/082QRJJiOvp3FGbgxTGyyxMxohPTjhk/W9bD2J0tk4ukITI7goOhOO2WbaHn/lsPmo/zf8+DIXhwpgYQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -3394,18 +3394,18 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.15.40",
-        "@swc/core-darwin-x64": "1.15.40",
-        "@swc/core-linux-arm-gnueabihf": "1.15.40",
-        "@swc/core-linux-arm64-gnu": "1.15.40",
-        "@swc/core-linux-arm64-musl": "1.15.40",
-        "@swc/core-linux-ppc64-gnu": "1.15.40",
-        "@swc/core-linux-s390x-gnu": "1.15.40",
-        "@swc/core-linux-x64-gnu": "1.15.40",
-        "@swc/core-linux-x64-musl": "1.15.40",
-        "@swc/core-win32-arm64-msvc": "1.15.40",
-        "@swc/core-win32-ia32-msvc": "1.15.40",
-        "@swc/core-win32-x64-msvc": "1.15.40"
+        "@swc/core-darwin-arm64": "1.15.41",
+        "@swc/core-darwin-x64": "1.15.41",
+        "@swc/core-linux-arm-gnueabihf": "1.15.41",
+        "@swc/core-linux-arm64-gnu": "1.15.41",
+        "@swc/core-linux-arm64-musl": "1.15.41",
+        "@swc/core-linux-ppc64-gnu": "1.15.41",
+        "@swc/core-linux-s390x-gnu": "1.15.41",
+        "@swc/core-linux-x64-gnu": "1.15.41",
+        "@swc/core-linux-x64-musl": "1.15.41",
+        "@swc/core-win32-arm64-msvc": "1.15.41",
+        "@swc/core-win32-ia32-msvc": "1.15.41",
+        "@swc/core-win32-x64-msvc": "1.15.41"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -3417,9 +3417,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.40.tgz",
-      "integrity": "sha512-PaYyclfmQ++77D8ityYvmmVzHv9aG8ROwt2GfG6/ccloy4Hgf80qtOnzb9VYvPsUT7Ty1uhuDRhv3XYpf62qhQ==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.41.tgz",
+      "integrity": "sha512-kREh6J5paQFvP3i7f/4FbqRNOJREutVFVOkder4GVyCBQ39YmER55cW/y1NNjwrchzFqgYswFn0mMDCqbqKzrw==",
       "cpu": [
         "arm64"
       ],
@@ -3434,9 +3434,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.40.tgz",
-      "integrity": "sha512-HbbPzvfLBUXjIB1Ezks+//lNUjmLjfyd63XSwprJgrZaXYdm70kohXPJUWdqKZozolFxbPaO+xtBaiUp6BoueA==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.41.tgz",
+      "integrity": "sha512-N8B56ESFazZAWZyIkecADSPCwlLEinW7QLMEeotCpv4J7VXwfH+OLkmRL8o96UZ+1355fwHxDTS6/wK7yucvkA==",
       "cpu": [
         "x64"
       ],
@@ -3451,9 +3451,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.40.tgz",
-      "integrity": "sha512-SlRZsCjOCPR2LvFs0Ri/Xrx/5o5TCt8vl4gW6mX1hEZOG0a625RxzRHpHdAQNGykmAN/7IeaFAJG+QnNmxlHcA==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.41.tgz",
+      "integrity": "sha512-6XrId2fyle0mS5xxON8rU84mPd2Cq1kDJRj+4BnQKTd7u+2kSA6Ww+JkOP0iTNqOqt9OXhPOEAjBHAuonWcdCg==",
       "cpu": [
         "arm"
       ],
@@ -3468,9 +3468,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.40.tgz",
-      "integrity": "sha512-Q8byxJt2fh8CR3EUX6snBpy47AoBVm+In/+Z3rjDHMjC38ZvR9/gtUUNCT0tfrn4EdVsO8/QPi59nxrxvqxvBQ==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.41.tgz",
+      "integrity": "sha512-ynLIarxlkVnqHn1D0fKOVht6mNU5ks6lrH+MY3kkS+XFaGGgDxFZVjWKJlkYTKm3RCvBTfA8Ng5fLufXheMRKQ==",
       "cpu": [
         "arm64"
       ],
@@ -3488,9 +3488,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.40.tgz",
-      "integrity": "sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.41.tgz",
+      "integrity": "sha512-dXu/5vd4gh8symyhRF+4G7gOPkjmb4pONhh7sl+6GSiW0LOKZlfu5kXmyFbTz9smOT7jgr002qY9b1nujjXt2A==",
       "cpu": [
         "arm64"
       ],
@@ -3508,9 +3508,9 @@
       }
     },
     "node_modules/@swc/core-linux-ppc64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.40.tgz",
-      "integrity": "sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.41.tgz",
+      "integrity": "sha512-XGO6zVPXoPE0gf/XnI4jBbafNT13AYgoh6ns0JCSdOetI/kqVf0vhpz7NuNgAzZrMVCsmieqjPoTwViDgh4mOQ==",
       "cpu": [
         "ppc64"
       ],
@@ -3528,9 +3528,9 @@
       }
     },
     "node_modules/@swc/core-linux-s390x-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.40.tgz",
-      "integrity": "sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.41.tgz",
+      "integrity": "sha512-0WUglRwyZtW+iMi7J3iFdrCxreZZIKf4egTwEQfIYRsqFax69A0OrFj+NIoFSE03xBT/IFRrg+S8K6f9Ky+4hA==",
       "cpu": [
         "s390x"
       ],
@@ -3548,9 +3548,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.40.tgz",
-      "integrity": "sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.41.tgz",
+      "integrity": "sha512-VxkuQK59c0tHm6uJZCUrS3cyA2JhGGfdU6e41SZz0x/JS+4Sm7C1mIc97In14vkZJopEt7yXA2TouCqZDSygEA==",
       "cpu": [
         "x64"
       ],
@@ -3568,9 +3568,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.40.tgz",
-      "integrity": "sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.41.tgz",
+      "integrity": "sha512-/0qXIu1ZxggLuovLb22vFfKHq2AA4n6Whw5UwmVCHk4pkw7KWnPIQpMCEqUMPsNkFJig7PPp/TSYFu8ZEb2rtQ==",
       "cpu": [
         "x64"
       ],
@@ -3588,9 +3588,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.40.tgz",
-      "integrity": "sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.41.tgz",
+      "integrity": "sha512-Y481sMNZM6rECh9VO4+y26N1lWEDAyxnBZskUf37fl90uHE946VHfmiVQWT0uMFOhyJJFovGTRuF4W82dwewUg==",
       "cpu": [
         "arm64"
       ],
@@ -3605,9 +3605,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.40.tgz",
-      "integrity": "sha512-yvwdPLGd25mcj/mNatjNQ0lZujtQD6psH3v9PNmMb+fSzjbNG8KIDxjFWrcV+fsFVLOkyOmdJsFmX7NAFjVyPw==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.41.tgz",
+      "integrity": "sha512-BAchBD5qeUzy3hiPSLJtaaoSm4blCLyYffOF1bGE4ETcV+OisqjUAwDQMJj++4bTpvMCDzwC+Bj3PmQyBCtscw==",
       "cpu": [
         "ia32"
       ],
@@ -3622,9 +3622,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.40.tgz",
-      "integrity": "sha512-OXtKsLU1bVtInzzDEAY2sYiF/rl4tvAnLLLpuMp3HzAOQZ5A+i69AKDhA1YLQTaMAqO3vzyYNVAYVRMPtSYD4w==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.41.tgz",
+      "integrity": "sha512-WOkA+fJ/ViVBQDsSV9JC52NACTe5PhlurA6viASDZGb7HR3KS01ZG7RZ+Bg6SVQFIoq3gSbTsskQVe6EbHFAYw==",
       "cpu": [
         "x64"
       ],
@@ -4714,6 +4714,18 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/archiver": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-8.0.0.tgz",
@@ -5050,9 +5062,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.34",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
-      "integrity": "sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==",
+      "version": "2.10.35",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.35.tgz",
+      "integrity": "sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -5874,9 +5886,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.369",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.369.tgz",
-      "integrity": "sha512-XM22K9FNaaCOvMMrBn1caIc8v0g6+pKt660ZbfQqUZvfil0hEzr8ZoiY7VcSLGM3L/x3rz5PqZrk+bKOOmVM9w==",
+      "version": "1.5.371",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz",
+      "integrity": "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -9867,9 +9879,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -9965,9 +9977,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
-      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
+      "integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -10440,9 +10452,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
-      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10807,16 +10819,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/stubs": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   },
   "dependencies": {
     "@causa/cli": "^1.0.0",
-    "@causa/workspace": "^1.0.0",
+    "@causa/workspace": "^1.0.1",
     "@causa/workspace-core": "^1.0.1",
-    "@causa/workspace-typescript": "^1.0.0",
+    "@causa/workspace-typescript": "^1.0.1",
     "@google-cloud/apikeys": "^2.2.2",
     "@google-cloud/bigquery": "^8.3.1",
     "@google-cloud/iam-credentials": "^4.2.2",
@@ -61,7 +61,7 @@
     "pino": "^10.3.1"
   },
   "devDependencies": {
-    "@swc/core": "^1.15.40",
+    "@swc/core": "^1.15.41",
     "@swc/jest": "^0.2.39",
     "@tsconfig/node22": "^22.0.5",
     "@types/jest": "^30.0.0",

--- a/src/functions/google-firestore/generate-typescript-decorators.spec.ts
+++ b/src/functions/google-firestore/generate-typescript-decorators.spec.ts
@@ -133,8 +133,12 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleFirestore', () => {
 
     expect(actual).toEqual([
       {
-        source: `@FirestoreCollection({ name: "my-collection", path: (doc) => doc.id })`,
-        imports: { '@causa/runtime-google': ['FirestoreCollection'] },
+        source: `@_CausaRuntimeGoogleFirestoreCollection({ name: "my-collection", path: (doc) => doc.id })`,
+        imports: {
+          '@causa/runtime-google': [
+            'FirestoreCollection as _CausaRuntimeGoogleFirestoreCollection',
+          ],
+        },
       },
     ]);
   });
@@ -155,13 +159,19 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleFirestore', () => {
 
     expect(actual).toEqual([
       {
-        source: `@FirestoreCollection({ name: "my-collection", path: (doc) => doc.id })`,
-        imports: { '@causa/runtime-google': ['FirestoreCollection'] },
+        source: `@_CausaRuntimeGoogleFirestoreCollection({ name: "my-collection", path: (doc) => doc.id })`,
+        imports: {
+          '@causa/runtime-google': [
+            'FirestoreCollection as _CausaRuntimeGoogleFirestoreCollection',
+          ],
+        },
       },
       {
-        source: '@SoftDeletedFirestoreCollection()',
+        source: '@_CausaRuntimeGoogleSoftDeletedFirestoreCollection()',
         imports: {
-          '@causa/runtime-google': ['SoftDeletedFirestoreCollection'],
+          '@causa/runtime-google': [
+            'SoftDeletedFirestoreCollection as _CausaRuntimeGoogleSoftDeletedFirestoreCollection',
+          ],
         },
       },
     ]);
@@ -188,7 +198,7 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleFirestore', () => {
     const actual = await callForClass(schema);
 
     expect(actual[0].source).toBe(
-      `@FirestoreCollection({ name: "my-collection", path: (doc) => ["users", doc.userId, "documents", doc.documentId].join("/") })`,
+      `@_CausaRuntimeGoogleFirestoreCollection({ name: "my-collection", path: (doc) => ["users", doc.userId, "documents", doc.documentId].join("/") })`,
     );
   });
 
@@ -267,6 +277,8 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleFirestore', () => {
     });
 
     expect(actual).toHaveLength(1);
-    expect(actual[0].source).toContain('@FirestoreCollection');
+    expect(actual[0].source).toContain(
+      '@_CausaRuntimeGoogleFirestoreCollection',
+    );
   });
 });

--- a/src/functions/google-firestore/generate-typescript-decorators.ts
+++ b/src/functions/google-firestore/generate-typescript-decorators.ts
@@ -103,7 +103,8 @@ export class ModelGenerateTypeScriptDecoratorsForGoogleFirestore extends ModelGe
       { schema: this.schema },
       'FirestoreCollection',
       CAUSA_GOOGLE_MODULE,
-      `@FirestoreCollection({ name: ${JSON.stringify(name)}, path: (doc) => ${pathExpression} })`,
+      (alias) =>
+        `@${alias}({ name: ${JSON.stringify(name)}, path: (doc) => ${pathExpression} })`,
     );
 
     if (hasSoftDelete === true) {
@@ -112,7 +113,7 @@ export class ModelGenerateTypeScriptDecoratorsForGoogleFirestore extends ModelGe
         { schema: this.schema },
         'SoftDeletedFirestoreCollection',
         CAUSA_GOOGLE_MODULE,
-        '@SoftDeletedFirestoreCollection()',
+        (alias) => `@${alias}()`,
       );
     }
 

--- a/src/functions/google-spanner/generate-typescript-decorators.spec.ts
+++ b/src/functions/google-spanner/generate-typescript-decorators.spec.ts
@@ -107,8 +107,12 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleSpanner', () => {
 
     expect(actual).toEqual([
       {
-        source: '@SpannerTable({"primaryKey":["id"]})',
-        imports: { '@causa/runtime-google': ['SpannerTable'] },
+        source: '@_CausaRuntimeGoogleSpannerTable({"primaryKey":["id"]})',
+        imports: {
+          '@causa/runtime-google': [
+            'SpannerTable as _CausaRuntimeGoogleSpannerTable',
+          ],
+        },
       },
     ]);
   });
@@ -121,7 +125,7 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleSpanner', () => {
     const actual = await callDecorators(schema);
 
     expect(actual[0].source).toBe(
-      '@SpannerTable({"primaryKey":["id"],"name":"users"})',
+      '@_CausaRuntimeGoogleSpannerTable({"primaryKey":["id"],"name":"users"})',
     );
   });
 
@@ -141,8 +145,12 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleSpanner', () => {
 
     expect(actual).toEqual([
       {
-        source: '@SpannerColumn()',
-        imports: { '@causa/runtime-google': ['SpannerColumn'] },
+        source: '@_CausaRuntimeGoogleSpannerColumn()',
+        imports: {
+          '@causa/runtime-google': [
+            'SpannerColumn as _CausaRuntimeGoogleSpannerColumn',
+          ],
+        },
       },
     ]);
   });
@@ -156,7 +164,9 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleSpanner', () => {
 
     const actual = await callDecorators(schema, { property });
 
-    expect(actual[0].source).toBe('@SpannerColumn({"isInt":true})');
+    expect(actual[0].source).toBe(
+      '@_CausaRuntimeGoogleSpannerColumn({"isInt":true})',
+    );
   });
 
   it('should infer isJson for map properties', async () => {
@@ -168,7 +178,9 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleSpanner', () => {
 
     const actual = await callDecorators(schema, { property });
 
-    expect(actual[0].source).toBe('@SpannerColumn({"isJson":true})');
+    expect(actual[0].source).toBe(
+      '@_CausaRuntimeGoogleSpannerColumn({"isJson":true})',
+    );
   });
 
   it('should infer isJson for refs to object schemas', async () => {
@@ -189,7 +201,9 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleSpanner', () => {
       schemas: { [schema.path]: schema, [nested.path]: nested },
     });
 
-    expect(actual[0].source).toBe('@SpannerColumn({"isJson":true})');
+    expect(actual[0].source).toBe(
+      '@_CausaRuntimeGoogleSpannerColumn({"isJson":true})',
+    );
   });
 
   it('should infer isJson for arrays of object refs', async () => {
@@ -214,7 +228,9 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleSpanner', () => {
       schemas: { [schema.path]: schema, [nested.path]: nested },
     });
 
-    expect(actual[0].source).toBe('@SpannerColumn({"isJson":true})');
+    expect(actual[0].source).toBe(
+      '@_CausaRuntimeGoogleSpannerColumn({"isJson":true})',
+    );
   });
 
   it('should infer isInt for arrays of integers', async () => {
@@ -227,7 +243,9 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleSpanner', () => {
 
     const actual = await callDecorators(schema, { property });
 
-    expect(actual[0].source).toBe('@SpannerColumn({"isInt":true})');
+    expect(actual[0].source).toBe(
+      '@_CausaRuntimeGoogleSpannerColumn({"isInt":true})',
+    );
   });
 
   it('should respect tsOptions overriding the inferred type', async () => {
@@ -242,7 +260,9 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleSpanner', () => {
 
     const actual = await callDecorators(schema, { property });
 
-    expect(actual[0].source).toBe('@SpannerColumn({"isBigInt":true})');
+    expect(actual[0].source).toBe(
+      '@_CausaRuntimeGoogleSpannerColumn({"isBigInt":true})',
+    );
   });
 
   it('should add the name option when overridden', async () => {
@@ -255,7 +275,9 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleSpanner', () => {
 
     const actual = await callDecorators(schema, { property });
 
-    expect(actual[0].source).toBe('@SpannerColumn({"name":"otherName"})');
+    expect(actual[0].source).toBe(
+      '@_CausaRuntimeGoogleSpannerColumn({"name":"otherName"})',
+    );
   });
 
   it('should add the softDelete option for the configured column', async () => {
@@ -272,7 +294,9 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleSpanner', () => {
       },
     });
 
-    expect(actual[0].source).toBe('@SpannerColumn({"softDelete":true})');
+    expect(actual[0].source).toBe(
+      '@_CausaRuntimeGoogleSpannerColumn({"softDelete":true})',
+    );
   });
 
   it('should return no decorators when the schema path does not match the configured globs', async () => {
@@ -296,6 +320,6 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleSpanner', () => {
     });
 
     expect(actual).toHaveLength(1);
-    expect(actual[0].source).toContain('@SpannerTable');
+    expect(actual[0].source).toContain('@_CausaRuntimeGoogleSpannerTable');
   });
 });

--- a/src/functions/google-spanner/generate-typescript-decorators.ts
+++ b/src/functions/google-spanner/generate-typescript-decorators.ts
@@ -99,7 +99,7 @@ export class ModelGenerateTypeScriptDecoratorsForGoogleSpanner extends ModelGene
       { schema: this.schema },
       'SpannerTable',
       CAUSA_GOOGLE_MODULE,
-      `@SpannerTable(${JSON.stringify({ primaryKey, name })})`,
+      (alias) => `@${alias}(${JSON.stringify({ primaryKey, name })})`,
     );
     return decorators;
   }
@@ -162,9 +162,10 @@ export class ModelGenerateTypeScriptDecoratorsForGoogleSpanner extends ModelGene
     }
 
     const hasOptions = Object.keys(columnAttributes).length > 0;
-    const source = hasOptions
-      ? `@SpannerColumn(${JSON.stringify(columnAttributes)})`
-      : '@SpannerColumn()';
+    const source = (alias: string) =>
+      hasOptions
+        ? `@${alias}(${JSON.stringify(columnAttributes)})`
+        : `@${alias}()`;
 
     const decorators: TypeScriptDecorator[] = [];
     addDecoratorToList(


### PR DESCRIPTION
### 📝 Description of the PR

The Google Spanner and Firestore decorator generators now emit aliased imports for the decorators they add (`@SpannerTable`, `@SpannerColumn`, `@FirestoreCollection`, `@SoftDeletedFirestoreCollection`). Each decorator is imported from `@causa/runtime-google` under a module-qualified alias and referenced through it, so the generated import can no longer clash with a generated type sharing the same name. This relies on the new function form of `addDecoratorToList` introduced in `@causa/workspace-typescript`, to which the modules have been upgraded.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.
