### PR TITLE
🔖 Prepare v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.0.1 (2026-06-10)
+
 Fixes:
 
 - Generate aliased imports for the Google Spanner and Firestore decorators (`@SpannerTable`, `@SpannerColumn`, `@FirestoreCollection`, `@SoftDeletedFirestoreCollection`), preventing the external decorator imports from clashing with generated type names.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-google",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-google",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-google",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The Causa workspace module providing many functionalities related to GCP and its services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes:

- Generate aliased imports for the Google Spanner and Firestore decorators (`@SpannerTable`, `@SpannerColumn`, `@FirestoreCollection`, `@SoftDeletedFirestoreCollection`), preventing the external decorator imports from clashing with generated type names.