### PR TITLE
✨ Improve Firestore decorator code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Features:
+
+- Make the `name` property of the `googleFirestoreCollection` schema extension optional. When it is not set, the `name` option is omitted from the generated `@FirestoreCollection` decorator.
+- Add the `google.firestore.pathAsArray` code generator configuration. When `true`, the generated `@FirestoreCollection` `path` function returns the path segments as an array instead of a slash-joined string.
+
 ## v1.0.1 (2026-06-10)
 
 Fixes:

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ additionalProperties: false
 causa:
   # This must be set for the decorators to be added to the class.
   googleFirestoreCollection:
-    # Mandatory, the name of the Firestore collection.
+    # Optional, the name of the Firestore collection.
+    # If not set, the `name` is omitted from the decorator options.
     name: myCollection
     # Mandatory, determines how to create the path for a document.
     path: [property: id]
@@ -166,6 +167,8 @@ model:
           # Same as Spanner globs.
           globs:
             - ../firestore/*.yaml
+          # Optional, generates the document path as an array of segments instead of a slash-joined string.
+          pathAsArray: true
 ```
 
 ## 🔨 Custom `google` commands

--- a/src/functions/google-firestore/generate-typescript-decorators.spec.ts
+++ b/src/functions/google-firestore/generate-typescript-decorators.spec.ts
@@ -222,6 +222,43 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleFirestore', () => {
     ]);
   });
 
+  it('should return the path as an array when pathAsArray is true', async () => {
+    const schema = makeSchema(
+      {
+        googleFirestoreCollection: { path: ['users', { property: 'userId' }] },
+      },
+      { properties: [makeProperty('userId')] },
+    );
+
+    const actual = await callForClass(schema, {
+      configuration: { google: { firestore: { pathAsArray: true } } },
+    });
+
+    expect(actual[0].source).toBe(
+      `@_CausaRuntimeGoogleFirestoreCollection({ path: (doc) => ["users", doc.userId] })`,
+    );
+  });
+
+  it('should return a single-element path as an array when pathAsArray is true', async () => {
+    const schema = makeSchema(
+      {
+        googleFirestoreCollection: {
+          name: 'my-collection',
+          path: [{ property: 'id' }],
+        },
+      },
+      { properties: [makeProperty('id')] },
+    );
+
+    const actual = await callForClass(schema, {
+      configuration: { google: { firestore: { pathAsArray: true } } },
+    });
+
+    expect(actual[0].source).toBe(
+      `@_CausaRuntimeGoogleFirestoreCollection({ path: (doc) => [doc.id], name: "my-collection" })`,
+    );
+  });
+
   it('should throw when the collection attribute name is not a string', () => {
     const schema = makeSchema({
       googleFirestoreCollection: { name: 123, path: [{ property: 'id' }] },

--- a/src/functions/google-firestore/generate-typescript-decorators.spec.ts
+++ b/src/functions/google-firestore/generate-typescript-decorators.spec.ts
@@ -133,7 +133,7 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleFirestore', () => {
 
     expect(actual).toEqual([
       {
-        source: `@_CausaRuntimeGoogleFirestoreCollection({ name: "my-collection", path: (doc) => doc.id })`,
+        source: `@_CausaRuntimeGoogleFirestoreCollection({ path: (doc) => doc.id, name: "my-collection" })`,
         imports: {
           '@causa/runtime-google': [
             'FirestoreCollection as _CausaRuntimeGoogleFirestoreCollection',
@@ -159,7 +159,7 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleFirestore', () => {
 
     expect(actual).toEqual([
       {
-        source: `@_CausaRuntimeGoogleFirestoreCollection({ name: "my-collection", path: (doc) => doc.id })`,
+        source: `@_CausaRuntimeGoogleFirestoreCollection({ path: (doc) => doc.id, name: "my-collection" })`,
         imports: {
           '@causa/runtime-google': [
             'FirestoreCollection as _CausaRuntimeGoogleFirestoreCollection',
@@ -198,17 +198,37 @@ describe('ModelGenerateTypeScriptDecoratorsForGoogleFirestore', () => {
     const actual = await callForClass(schema);
 
     expect(actual[0].source).toBe(
-      `@_CausaRuntimeGoogleFirestoreCollection({ name: "my-collection", path: (doc) => ["users", doc.userId, "documents", doc.documentId].join("/") })`,
+      `@_CausaRuntimeGoogleFirestoreCollection({ path: (doc) => ["users", doc.userId, "documents", doc.documentId].join("/"), name: "my-collection" })`,
     );
   });
 
-  it('should throw when the collection attribute is missing name', () => {
+  it('should omit the name from the decorator when the collection attribute has no name', async () => {
+    const schema = makeSchema(
+      { googleFirestoreCollection: { path: [{ property: 'id' }] } },
+      { properties: [makeProperty('id')] },
+    );
+
+    const actual = await callForClass(schema);
+
+    expect(actual).toEqual([
+      {
+        source: `@_CausaRuntimeGoogleFirestoreCollection({ path: (doc) => doc.id })`,
+        imports: {
+          '@causa/runtime-google': [
+            'FirestoreCollection as _CausaRuntimeGoogleFirestoreCollection',
+          ],
+        },
+      },
+    ]);
+  });
+
+  it('should throw when the collection attribute name is not a string', () => {
     const schema = makeSchema({
-      googleFirestoreCollection: { path: [{ property: 'id' }] },
+      googleFirestoreCollection: { name: 123, path: [{ property: 'id' }] },
     });
 
     expect(() => callForClass(schema)).toThrow(
-      `Expected an object with a 'name' string property`,
+      `Expected the 'name' property to be a string`,
     );
   });
 

--- a/src/functions/google-firestore/generate-typescript-decorators.ts
+++ b/src/functions/google-firestore/generate-typescript-decorators.ts
@@ -57,9 +57,9 @@ export class ModelGenerateTypeScriptDecoratorsForGoogleFirestore extends ModelGe
       path?: unknown;
       hasSoftDelete?: unknown;
     };
-    if (typeof name !== 'string') {
+    if (name !== undefined && typeof name !== 'string') {
       throw new Error(
-        `Invalid '${GOOGLE_FIRESTORE_COLLECTION_EXTENSION}' attribute on '${debugName}'. Expected an object with a 'name' string property.`,
+        `Invalid '${GOOGLE_FIRESTORE_COLLECTION_EXTENSION}' attribute on '${debugName}'. Expected the 'name' property to be a string.`,
       );
     }
     if (!Array.isArray(path)) {
@@ -97,14 +97,18 @@ export class ModelGenerateTypeScriptDecoratorsForGoogleFirestore extends ModelGe
     const pathExpression =
       path.length === 1 ? elements[0] : `[${elements.join(', ')}].join("/")`;
 
+    const decoratorOptions = [`path: (doc) => ${pathExpression}`];
+    if (name !== undefined) {
+      decoratorOptions.push(`name: ${JSON.stringify(name)}`);
+    }
+
     const decorators: TypeScriptDecorator[] = [];
     addDecoratorToList(
       decorators,
       { schema: this.schema },
       'FirestoreCollection',
       CAUSA_GOOGLE_MODULE,
-      (alias) =>
-        `@${alias}({ name: ${JSON.stringify(name)}, path: (doc) => ${pathExpression} })`,
+      (alias) => `@${alias}({ ${decoratorOptions.join(', ')} })`,
     );
 
     if (hasSoftDelete === true) {

--- a/src/functions/google-firestore/generate-typescript-decorators.ts
+++ b/src/functions/google-firestore/generate-typescript-decorators.ts
@@ -35,7 +35,9 @@ export class ModelGenerateTypeScriptDecoratorsForGoogleFirestore extends ModelGe
       return [];
     }
 
-    const globs = (this.configuration as any)?.google?.firestore?.globs;
+    const firestoreConfiguration = (this.configuration as any)?.google
+      ?.firestore;
+    const globs = firestoreConfiguration?.globs;
     if (Array.isArray(globs)) {
       const projectPath = this._context.getProjectPathOrThrow();
       const absoluteGlobs = globs.map((g) => join(projectPath, g));
@@ -95,7 +97,11 @@ export class ModelGenerateTypeScriptDecoratorsForGoogleFirestore extends ModelGe
     });
 
     const pathExpression =
-      path.length === 1 ? elements[0] : `[${elements.join(', ')}].join("/")`;
+      firestoreConfiguration?.pathAsArray === true
+        ? `[${elements.join(', ')}]`
+        : path.length === 1
+          ? elements[0]
+          : `[${elements.join(', ')}].join("/")`;
 
     const decoratorOptions = [`path: (doc) => ${pathExpression}`];
     if (name !== undefined) {


### PR DESCRIPTION
### 📝 Description of the PR

This PR brings two improvements to the generation of `@FirestoreCollection` decorators from the `googleFirestoreCollection` schema extension:

- The `name` property of the extension is now optional. When it is not set, the `name` option is simply omitted from the generated decorator, which is useful for collections where the runtime does not need an explicit collection name.
- A new `google.firestore.pathAsArray` code generator configuration can be set to `true` to make the generated `path` function return the path segments as an array instead of a slash-joined string.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.