### PR TITLE
🔖 Prepare v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.1.0 (2026-06-10)
+
 Features:
 
 - Make the `name` property of the `googleFirestoreCollection` schema extension optional. When it is not set, the `name` option is omitted from the generated `@FirestoreCollection` decorator.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-google",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-google",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-google",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "The Causa workspace module providing many functionalities related to GCP and its services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Features:

- Make the `name` property of the `googleFirestoreCollection` schema extension optional. When it is not set, the `name` option is omitted from the generated `@FirestoreCollection` decorator.
- Add the `google.firestore.pathAsArray` code generator configuration. When `true`, the generated `@FirestoreCollection` `path` function returns the path segments as an array instead of a slash-joined string.