### PR TITLE
🔖 Prepare v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.2.0 (2026-06-11)
+
 Features:
 
 - Implement `ModelGenerateTypeScriptTriggerDecorators` for the Google platform. When generating NestJS event controllers, each trigger-handling method receives a `@UseEventHandler` decorator with the handler ID matching the trigger type: `PUBSUB_EVENT_HANDLER_ID` for `event` / `google.pubSub`, `CLOUD_TASKS_EVENT_HANDLER_ID` for `task` / `google.tasks`, `CLOUD_SCHEDULER_EVENT_HANDLER_ID` for `cron` / `google.scheduler`, and `CLOUDEVENTS_EVENT_HANDLER_ID` for `google.eventarc`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-google",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-google",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-google",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "The Causa workspace module providing many functionalities related to GCP and its services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Features:

- Implement `ModelGenerateTypeScriptTriggerDecorators` for the Google platform. When generating NestJS event controllers, each trigger-handling method receives a `@UseEventHandler` decorator with the handler ID matching the trigger type: `PUBSUB_EVENT_HANDLER_ID` for `event` / `google.pubSub`, `CLOUD_TASKS_EVENT_HANDLER_ID` for `task` / `google.tasks`, `CLOUD_SCHEDULER_EVENT_HANDLER_ID` for `cron` / `google.scheduler`, and `CLOUDEVENTS_EVENT_HANDLER_ID` for `google.eventarc`.
