### PR TITLE
🔖 Prepare v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.3.0 (2026-07-24)
+
 Features:
 
 - Populate the `id` of `QueriedEvent`s returned by `EventTopicQueryEventsForBigQuery` with the Pub/Sub `message_id` column read from the BigQuery raw events table.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-google",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-google",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-google",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "The Causa workspace module providing many functionalities related to GCP and its services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Features:

- Populate the `id` of `QueriedEvent`s returned by `EventTopicQueryEventsForBigQuery` with the Pub/Sub `message_id` column read from the BigQuery raw events table.
- Populate the `id` of `QueriedLogEntry`s returned by `ServiceContainerQueryLogsForCloudRun` with the Cloud Logging entry `insertId`.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~