### PR TITLE
🔖 Prepare v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.3.1 (2026-08-06)
+
 Fixes:
 
 - Change the accepted values for the `google.cloudRun.ingress` configuration to upper snake case. The previous values were the ones accepted by the `gcloud` CLI and the Cloud Run v1 API annotation, not the ones expected by the Cloud Run v2 API and the Cloud Run service container Terraform module.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-google",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-google",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-google",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "The Causa workspace module providing many functionalities related to GCP and its services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes:

- Change the accepted values for the `google.cloudRun.ingress` configuration to upper snake case. The previous values were the ones accepted by the `gcloud` CLI and the Cloud Run v1 API annotation, not the ones expected by the Cloud Run v2 API and the Cloud Run service container Terraform module.
